### PR TITLE
Add CINO tracker artifacts: OPERATIONAL/BACKUP, FRICTION-001, WAITING-FOR-001

### DIFF
--- a/BACKUP-RESOURCES.md
+++ b/BACKUP-RESOURCES.md
@@ -1,0 +1,68 @@
+# Backup Resources
+
+Index of how SecID-Service operational state is backed up. Pairs with [OPERATIONAL-RESOURCES.md](OPERATIONAL-RESOURCES.md) (what runs vs. how it survives).
+
+---
+
+## Registry data (`secid_REGISTRY` KV)
+
+**What's being backed up.** The compiled registry data the Worker reads at request time. Note: the KV itself is *not* directly backed up — it's a cache, regenerable from authoritative sources.
+
+- **Where it lives in production:** Cloudflare KV namespace `cfbc271787614516a39fa43d9ca4f95a` on account `f3898058ae0b4c20c692bbfa5b9b44b0`
+- **Backup repo:** [CloudSecurityAlliance/SecID](https://github.com/CloudSecurityAlliance/SecID) — the authoritative source. KV is rebuilt from `registry/**/*.json` via `scripts/build-registry.ts`
+- **Backup mechanism:** Git on GitHub (the SecID spec repo); GitHub itself is backed up via [`CSA-Backups-GitHub`](https://github.com/CloudSecurityAlliance-Backups/CSA-Backups-GitHub) for org-wide metadata
+- **Cadence:** continuous (every commit to SecID main is a new "backup" point)
+- **Last verified:** 2026-05-07 (registry repo present on GitHub, regeneration tested via `--dry-run` of `upload-registry-kv.ts`)
+- **Recovery path:** With a working Cloudflare API token, run `npx tsx scripts/upload-registry-kv.ts --sync /path/to/SecID` from this repo. KV is fully reconstructed from JSON files in ~30 seconds. *Currently blocked by* [FRICTION-001](FRICTION/FRICTION-001.md)
+- **Owner:** Kurt Seifried
+- **Notes:** Recovery has been functionally untested at scale since 2026-04-30 due to the deploy chain breakage. Once FRICTION-001 is resolved, perform a full sync to confirm recovery path works end-to-end
+
+## Observability data (`secid_OBSERVABILITY` KV)
+
+**What's being backed up.** Error and access log records.
+
+- **Where it lives in production:** Cloudflare KV namespace `c5cbc52b9a724433b3043efdf31857f4`
+- **Backup repo:** **none — not backed up by design**
+- **Backup mechanism:** N/A
+- **Cadence:** N/A
+- **Last verified:** N/A
+- **Recovery path:** Logs are ephemeral; data loss is acceptable. New errors will be recorded as they occur
+- **Owner:** Kurt Seifried
+- **Notes:** Retention policy not yet defined (see OPERATIONAL-RESOURCES.md "Next review: 2026-09-01"). If observability data ever becomes load-bearing for compliance or incident analysis, this entry needs to change
+
+## DNS — `secid.cloudsecurityalliance.org`
+
+**What's being backed up.** The DNS A/AAAA records and Worker route binding for the public hostname.
+
+- **Where it lives in production:** Cloudflare DNS, zone `113bb8004441490558a7ce8b4b611cc1` (`cloudsecurityalliance.org`)
+- **Backup repo:** [CloudSecurityAlliance-Backups/CSA-Backups-CloudFlare](https://github.com/CloudSecurityAlliance-Backups/CSA-Backups-CloudFlare) — captures DNS records and Cloudflare configs across CSA properties
+- **Backup mechanism:** Periodic export from Cloudflare API (mechanism owned by `CSA-Backups-Management` project)
+- **Cadence:** see CSA-Backups-CloudFlare README
+- **Last verified:** check `CSA-Backups-CloudFlare/cloudsecurityalliance.org/` for the most recent export timestamp
+- **Recovery path:** Restore DNS records from the BIND/JSON dump in `CSA-Backups-CloudFlare`. Worker route binding is also encoded in [`wrangler.toml`](wrangler.toml) here, so a fresh `wrangler deploy` re-establishes it
+- **Owner:** Kurt Seifried (DNS owner); CSA-Backups-Management owns the backup pipeline
+
+## Worker code + config
+
+**What's being backed up.** The Worker source code, `wrangler.toml`, GitHub Actions workflows, and all deployment scripts.
+
+- **Where it lives in production:** Compiled bundle on Cloudflare's edge (rebuilt on each `wrangler deploy`)
+- **Backup repo:** [CloudSecurityAlliance/SecID-Service](https://github.com/CloudSecurityAlliance/SecID-Service) (this repo) — source of truth
+- **Backup mechanism:** Git on GitHub, plus [`CSA-Backups-GitHub`](https://github.com/CloudSecurityAlliance-Backups/CSA-Backups-GitHub) for org metadata
+- **Cadence:** continuous (every commit)
+- **Last verified:** 2026-05-07 (this commit)
+- **Recovery path:** `git clone` + `npm ci` + `npx wrangler deploy` (with `CLOUDFLARE_API_TOKEN` set)
+- **Owner:** Kurt Seifried
+
+## Cloudflare account secrets
+
+**What's being backed up.** GitHub Actions secrets used by the deploy chain: `SECID_TO_SERVICE_DISPATCH` (PAT for cross-repo dispatch) and `SECID_SERVICE_DEPLOY` (Cloudflare API token).
+
+- **Where it lives in production:** GitHub repository secrets (SecID and SecID-Service repos respectively)
+- **Backup repo:** **none — secrets are not version-controlled by design**
+- **Backup mechanism:** N/A; tokens are recreated/rotated as needed
+- **Cadence:** N/A
+- **Last verified:** 2026-04-30 (last known working state; one or both have lapsed since per FRICTION-001)
+- **Recovery path:** Regenerate the GitHub PAT (fine-grained, scoped to SecID-Service only) and the Cloudflare API token (Workers KV Edit + Workers Scripts Edit on the SecID-Service Worker), then update the corresponding GitHub repository secret
+- **Owner:** Kurt Seifried
+- **Notes:** Token rotation policy not formalized. Each token's permissions and scope should be documented in a runbook; for now, see the GitHub Actions workflow definitions for which token does what

--- a/FRICTION.md
+++ b/FRICTION.md
@@ -1,0 +1,7 @@
+# Friction Log
+
+Friction log for SecID-Service. Each entry is work that shouldn't be as hard as it is. See [`FRICTION/`](FRICTION/) for individual entries.
+
+| ID | Title | Status | Type | Date |
+|----|-------|--------|------|------|
+| [FRICTION-001](FRICTION/FRICTION-001.md) | KV deploy chain blocked | Open | Process overhead | 2026-04-30 |

--- a/FRICTION/FRICTION-001.md
+++ b/FRICTION/FRICTION-001.md
@@ -1,0 +1,74 @@
+# FRICTION-001: KV deploy chain blocked
+
+**Status:** Open
+**Date identified:** 2026-04-30
+**Date resolved:** —
+**Type:** Process overhead
+
+## Description
+
+The auto-deploy chain that pushes registry JSON changes from the SecID spec repo to the live KV-backed resolver has been broken since 2026-04-30. Two independent failures stack:
+
+1. **Auto-trigger fails.** Push to `main` in the SecID repo touching `registry/**/*.json` runs `update-registry.yml`, which uses `peter-evans/repository-dispatch@v3` with the `SECID_TO_SERVICE_DISPATCH` PAT to send a `repository_dispatch` event to SecID-Service. The dispatch step now returns *unauthorized* — the token has either expired, been revoked, or lost the required scope.
+2. **Manual `workflow_dispatch` of Stage 2 fails.** Even bypassing the dispatch token by triggering `registry-kv-upload.yml` directly, the workflow fails on the `npx vitest run` step due to one or more `cve-schema` test failures introduced by registry content changes that the test harness no longer accepts.
+
+The combined effect: registry content changes accumulate in `main` but cannot reach `secid_REGISTRY` KV. Currently stalled work includes 14 new CSAF advisory entries, 5 updated CSAF entries, and the format metadata fields (`parsability`, `schema`, `parsing_instructions`, `auth`) added across all URL objects.
+
+## Attention tax
+
+**Significant.** Every registry-touching commit is shadowed by "this isn't reaching production" — degrades the value of registry contributions, encourages batching changes (which itself adds friction), and erodes confidence in the auto-deploy pattern. Feels worse on days where multiple namespaces are added because the gap widens visibly.
+
+## Reproduction
+
+### Stage 1 (token failure)
+
+1. Push a change to `registry/<type>/<tld>/<file>.json` in [CloudSecurityAlliance/SecID](https://github.com/CloudSecurityAlliance/SecID) `main`
+2. Observe `Notify registry update` workflow run at https://github.com/CloudSecurityAlliance/SecID/actions
+3. Step "Trigger SecID-Service registry upload" fails with HTTP 401/403 from GitHub's repository-dispatch API
+
+### Stage 2 (test failure)
+
+1. Trigger `Upload registry to KV` manually: `gh workflow run "Upload registry to KV" -R CloudSecurityAlliance/SecID-Service`
+2. Observe run logs at https://github.com/CloudSecurityAlliance/SecID-Service/actions
+3. `Run tests` step (`npx vitest run`) fails on `cve-schema`-related test cases
+
+## Workaround
+
+**No working production path for KV updates as of 2026-05-07.**
+
+Local dry-run audit (no mutations, requires working `CLOUDFLARE_API_TOKEN`):
+
+```bash
+cd /path/to/SecID-Service
+CLOUDFLARE_API_TOKEN=<token> npx tsx scripts/upload-registry-kv.ts --sync --dry-run /path/to/SecID
+```
+
+This shows what would be uploaded without doing it. Useful to confirm the registry build is sound while the test gate is broken.
+
+## Root cause hypotheses
+
+**Stage 1 (more straightforward):**
+- Fine-grained PAT `SECID_TO_SERVICE_DISPATCH` may have hit its 1-year max lifetime
+- Token may have lost the `metadata: read` + `contents: read` permission via permission audit
+- SecID-Service repository-dispatch permission may have been changed to require higher scopes
+
+**Stage 2 (needs investigation):**
+- A registry contribution introduced a JSON shape that violates a Vitest schema fixture's expectations
+- The `cve-schema` test suite likely tests that a specific CVE schema file (registry entry?) parses to a specific shape, and the underlying file changed
+- Less likely: a Vitest version mismatch from a dependency bump
+
+## Resolution plan
+
+1. Inspect `gh run view --log-failed` for the most recent failed run to identify the exact assertion in `cve-schema`
+2. Either fix the registry data, fix the test expectation, or fix the schema (whichever is genuinely wrong)
+3. Get a successful local `npx vitest run`
+4. Regenerate `SECID_TO_SERVICE_DISPATCH` with appropriate scope; update GitHub repository secret
+5. Trigger end-to-end test: `gh workflow run "Notify registry update" -R CloudSecurityAlliance/SecID`
+6. Confirm KV is populated and Worker is redeployed
+7. Move all stalled registry content (14 new CSAF entries + format metadata) into production
+8. Mark this friction Resolved; add a runbook to `OPERATIONAL-RESOURCES.md` for token rotation cadence
+
+## Related
+
+- [WAITING-FOR-001](../WAITING-FOR/WAITING-FOR-001.md) — registry content waiting on this resolution
+- [OPERATIONAL-RESOURCES.md](../OPERATIONAL-RESOURCES.md) — "GitHub Actions — Deploy chain (cross-repo)" section

--- a/OPERATIONAL-RESOURCES.md
+++ b/OPERATIONAL-RESOURCES.md
@@ -1,0 +1,90 @@
+# Operational Resources
+
+Index of recurring operational work for SecID-Service. Pairs with [BACKUP-RESOURCES.md](BACKUP-RESOURCES.md) (what runs vs. how it survives).
+
+---
+
+## Cloudflare Worker — `secid-service`
+
+**What it does.** Serves the live SecID resolver and MCP server at `secid.cloudsecurityalliance.org`. Hosts the `/api/v1/resolve`, `/api/v1/lookup`, `/api/v1/describe`, `/mcp`, `/.well-known/*`, and the Astro static site (`website/dist`).
+
+- **Code:** [`src/index.ts`](src/index.ts), [`src/mcp.ts`](src/mcp.ts), [`src/resolver.ts`](src/resolver.ts)
+- **Config:** [`wrangler.toml`](wrangler.toml) — Worker name `secid-service`, account `f3898058ae0b4c20c692bbfa5b9b44b0`, route `secid.cloudsecurityalliance.org/*` (zone `113bb8004441490558a7ce8b4b611cc1`)
+- **Runtime:** Cloudflare Workers (V8 isolates, edge-distributed)
+- **Inputs:** HTTP requests, KV reads from `secid_REGISTRY`
+- **Outputs:** JSON resolver responses, MCP JSON-RPC responses, static HTML, error records into `secid_OBSERVABILITY`
+- **Status:** production
+- **Last touched:** 2026-04-30
+- **Next review:** 2026-08-01
+- **Cadence:** request-driven (no schedule)
+- **Health check:** `curl https://secid.cloudsecurityalliance.org/api/v1/resolve?secid=secid:advisory/mitre.org/cve%23CVE-2021-44228` — should return JSON envelope with a URL
+- **Runbook:** Manual deploy via `npx wrangler deploy` (uses `CLOUDFLARE_API_TOKEN` env). Auto-deploy via `registry-kv-upload.yml` (see below)
+- **Owner:** Kurt Seifried
+- **Notes:** Astro site is bundled into the same Worker via `[assets]` in `wrangler.toml`
+
+## KV namespace — `secid_REGISTRY`
+
+**What it does.** Backing store for compiled registry data the Worker reads at request time. Each key is a namespace lookup; value is the JSON registry entry. Built from `registry/**/*.json` in the SecID spec repo via `scripts/build-registry.ts`.
+
+- **Code:** [`scripts/build-registry.ts`](scripts/build-registry.ts), [`scripts/upload-registry-kv.ts`](scripts/upload-registry-kv.ts)
+- **Binding ID:** `cfbc271787614516a39fa43d9ca4f95a` (preview: `bda410b73cc34b468c84bf2dc9fba45f`)
+- **Runtime:** Cloudflare KV
+- **Inputs:** registry JSON files in [CloudSecurityAlliance/SecID](https://github.com/CloudSecurityAlliance/SecID) `registry/**/*.json` (724 namespaces as of 2026-05-07)
+- **Outputs:** KV keys consumed by the Worker resolver
+- **Status:** production
+- **Last touched:** 2026-04-30 (last successful sync — chain has been broken since)
+- **Next review:** unblock as part of FRICTION-001 resolution; then quarterly thereafter
+- **Cadence:** auto-synced on push to `registry/**/*.json` in the SecID repo
+- **Health check:** `wrangler kv key list --namespace-id=cfbc271787614516a39fa43d9ca4f95a | wc -l` should match the namespace count produced by `build-registry.ts`
+- **Runbook:** `npx tsx scripts/upload-registry-kv.ts --sync /path/to/SecID` from this repo with `CLOUDFLARE_API_TOKEN` set to a token that has Workers KV Edit permission. `--sync` mode overwrites changed keys and deletes orphans (with a 50-key safety threshold)
+- **Owner:** Kurt Seifried
+
+## KV namespace — `secid_OBSERVABILITY`
+
+**What it does.** Always-on error and access log store with UUIDv7 IDs. Errors are written via `buildErrorEntry()` + `recordError()` from `src/observability.ts`. Used for post-hoc debugging and operational visibility.
+
+- **Code:** [`src/observability.ts`](src/observability.ts)
+- **Binding ID:** `c5cbc52b9a724433b3043efdf31857f4` (preview: `3bc7078377cb44bc8fc63e5f9f344392`)
+- **Runtime:** Cloudflare KV
+- **Inputs:** errors raised by Worker request handlers; request metadata
+- **Outputs:** KV keys (UUIDv7-named) for inspection via `wrangler kv key list`
+- **Status:** production
+- **Last touched:** 2026-03-05 (initial deployment)
+- **Next review:** 2026-09-01 (review retention strategy; KV has no TTL set)
+- **Cadence:** continuous, request-driven
+- **Health check:** `wrangler kv key list --namespace-id=c5cbc52b9a724433b3043efdf31857f4 | head` — non-empty list during error conditions, empty during clean operation
+- **Runbook:** Read individual entries with `wrangler kv key get --namespace-id=c5cbc52b9a724433b3043efdf31857f4 <key>`. UUIDv7 IDs sort lexicographically by time, so most recent errors are at the end of the listing
+- **Owner:** Kurt Seifried
+- **Notes:** No retention policy yet; will need pruning strategy as volume grows. Philosophy doc: `CINO-Platform-Engineering/research/operational-excellence/OPERATIONAL-PHILOSOPHY.md`
+
+## GitHub Actions — Deploy chain (cross-repo)
+
+**What it does.** Two-stage auto-deploy from registry JSON changes to live KV + Worker:
+
+1. **Stage 1 (SecID repo):** [`update-registry.yml`](https://github.com/CloudSecurityAlliance/SecID/blob/main/.github/workflows/update-registry.yml) — fires on push to `main` touching `registry/**/*.json`; sends `repository_dispatch` to SecID-Service using `SECID_TO_SERVICE_DISPATCH` PAT
+2. **Stage 2 (this repo):** [`.github/workflows/registry-kv-upload.yml`](.github/workflows/registry-kv-upload.yml) — receives dispatch, checks out both repos, runs `build-registry.ts`, builds website, runs `vitest`, uploads to KV in `--sync` mode using `SECID_SERVICE_DEPLOY` Cloudflare token, deploys Worker
+
+- **Runtime:** GitHub Actions runners (`ubuntu-latest`, Node 22)
+- **Inputs:** push events on registry JSON; `repository_dispatch` events of type `registry-updated`
+- **Outputs:** updated `secid_REGISTRY` KV; redeployed Worker
+- **Status:** **broken** since 2026-04-30 — see [FRICTION-001](FRICTION/FRICTION-001.md) and [WAITING-FOR-001](WAITING-FOR/WAITING-FOR-001.md). Auto-trigger fails (`SECID_TO_SERVICE_DISPATCH` token unauthorized); manual `workflow_dispatch` of Stage 2 fails on `cve-schema` Vitest test failure
+- **Last touched:** 2026-04-30
+- **Next review:** weekly until FRICTION-001 is resolved; then 2026-09-01
+- **Cadence:** event-driven (every push to `registry/**/*.json`)
+- **Health check:** `gh run list --workflow=registry-kv-upload.yml --limit 3 -R CloudSecurityAlliance/SecID-Service` — most recent run should be `success`. Currently shows `failure`/no-recent-runs
+- **Runbook:** See FRICTION-001 for current breakage and partial workarounds. Local audit (no mutations): `npx tsx scripts/upload-registry-kv.ts --sync --dry-run /path/to/SecID` from this repo with a working `CLOUDFLARE_API_TOKEN`
+- **Owner:** Kurt Seifried
+
+## DNS — `secid.cloudsecurityalliance.org`
+
+**What it does.** Resolves the public hostname to the Worker route. Configured in Cloudflare DNS for `cloudsecurityalliance.org` zone (`113bb8004441490558a7ce8b4b611cc1`).
+
+- **Runtime:** Cloudflare DNS
+- **Status:** production
+- **Last touched:** initial setup (2026-04 launch)
+- **Next review:** 2026-09-01
+- **Cadence:** static
+- **Health check:** `dig secid.cloudsecurityalliance.org +short` — should return Cloudflare anycast IPs
+- **Runbook:** Cloudflare dashboard → cloudsecurityalliance.org → DNS. Worker route binding in `wrangler.toml`
+- **Owner:** Kurt Seifried
+- **Notes:** Backed up in [BACKUP-RESOURCES.md](BACKUP-RESOURCES.md)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ No authentication. CORS enabled.
 - **Registry:** Compiled from [SecID](https://github.com/CloudSecurityAlliance/SecID) registry JSON files (700+ namespaces, 10 types)
 - **Website:** Astro static site served from the same Worker
 
+## Planned: also runs under the CSA MCP Server front door
+
+Today SecID-Service runs only at `secid.cloudsecurityalliance.org/mcp` (anonymous, no auth — the friction-free public utility). Per [CSA-MCP-Server ADR-002](https://github.com/CloudSecurityAlliance-Internal/CSA-MCP-Server/blob/main/DECISIONS.md#adr-002-federation-strategy--monolith-composition-now-service-bindings-later-dual-shape-capabilities-with-two-welcome-variants), every capability ships in two shapes — a standalone deploy (this Worker, unchanged) AND a plugin form consumed by [CSA-MCP-Server](https://github.com/CloudSecurityAlliance-Internal/CSA-MCP-Server) at `cloudsecurityalliance.org/mcp` (Auth0-gated, alongside Search and future Working Groups / Training / Navigator).
+
+SecID is the likely first test of the two-shapes pattern because it already exists as a working standalone Worker. The refactor is to lift the tool *logic* (the resolve / lookup / describe data work — currently in `src/mcp.ts`) into a shared package that both this Worker's `mcp.ts` AND a new front-door plugin package import. Standalone keeps anonymous access; front door adds Auth0 on top. A SecID-specific ADR (forthcoming, will live here in this repo's DECISIONS.md or DECISIONS-ADR.md) will document the concrete refactor steps when work starts.
+
+This is forward-looking — no code change today, just signal that the repo's role is broadening.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+```
+project_tracker_base: CINO Project Tracker:appf7fRQUvY9Iy7sL
+project_tracker_table: Projects:tblchmbxSAavvJKaY
+project_tracker_record: SecID-Service:recJ2sF2CudDqTJRN
+project_source: github:CloudSecurityAlliance-Internal/CINO-Projects/projects/SecID-Service
+```
+
 # SecID-Service
 
 REST API and MCP server for resolving security identifiers to URLs. A [Cloud Security Alliance](https://cloudsecurityalliance.org) project by Kurt Seifried, Chief Innovation Officer.
@@ -12,7 +19,7 @@ Add SecID to your AI assistant as a remote MCP server:
 https://secid.cloudsecurityalliance.org/mcp
 ```
 
-That's it. No API keys, no local install, no configuration. Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP client that supports remote servers. Your AI assistant gets three tools (`resolve`, `lookup`, `describe`) and can immediately look up CVEs, CWEs, ATT&CK techniques, NIST controls, and 700+ other security knowledge sources.
+That's it. No API keys, no local install, no configuration. Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP client that supports remote servers. Your AI assistant gets three tools (`resolve`, `lookup`, `describe`) and can immediately look up CVEs, CWEs, ATT&CK techniques, NIST controls, and 724 other security knowledge sources.
 
 **Other ways to use SecID:** [Claude Code plugin](https://github.com/CloudSecurityAlliance/SecID/tree/main/plugins/secid) (local MCP server, supports internal resolvers) | [Client SDKs](https://github.com/CloudSecurityAlliance/SecID-Client-SDK) (Python, TypeScript, Go) | REST API (below)
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Today SecID-Service runs only at `secid.cloudsecurityalliance.org/mcp` (anonymou
 
 SecID is the likely first test of the two-shapes pattern because it already exists as a working standalone Worker. The refactor is to lift the tool *logic* (the resolve / lookup / describe data work — currently in `src/mcp.ts`) into a shared package that both this Worker's `mcp.ts` AND a new front-door plugin package import. Standalone keeps anonymous access; front door adds Auth0 on top. A SecID-specific ADR (forthcoming, will live here in this repo's DECISIONS.md or DECISIONS-ADR.md) will document the concrete refactor steps when work starts.
 
+**The umbrella SecID will join:**
+
+| Repo | Role |
+|---|---|
+| [CSA-MCP-Server](https://github.com/CloudSecurityAlliance-Internal/CSA-MCP-Server) | The front-door composition — deploys to `cloudsecurityalliance.org/mcp`. Will import SecID's plugin form alongside the Search plugin. |
+| [CSA-MCP-Core](https://github.com/CloudSecurityAlliance-Internal/CSA-MCP-Core) | Shared infrastructure library — auth, rate limits, observability, MCP protocol plumbing. SecID's plugin form will import this; standalone SecID may also adopt it incrementally for DRY observability/safety helpers. |
+| [CSA-Search-2.0](https://github.com/CloudSecurityAlliance-Internal/CSA-Search-2.0) | First non-platform plugin (search / ask / get_artifact). The pattern SecID's plugin form will follow. |
+| [CINO-Products / csa-mcp-server](https://github.com/CloudSecurityAlliance-Internal/CINO-Products/tree/main/products/csa-mcp-server) | Product-level umbrella — strategic positioning, capability roadmap. |
+
 This is forward-looking — no code change today, just signal that the repo's role is broadening.
 
 ## Development

--- a/WAITING-FOR.md
+++ b/WAITING-FOR.md
@@ -1,0 +1,7 @@
+# Waiting For
+
+Strategic-waiting log for SecID-Service. Each entry has a specific trigger that signals when to act. See [`WAITING-FOR/`](WAITING-FOR/) for individual entries.
+
+| ID | Title | Status | Type | Date |
+|----|-------|--------|------|------|
+| [WAITING-FOR-001](WAITING-FOR/WAITING-FOR-001.md) | Registry content propagation to live KV | Open | Decision | 2026-04-30 |

--- a/WAITING-FOR/WAITING-FOR-001.md
+++ b/WAITING-FOR/WAITING-FOR-001.md
@@ -1,0 +1,49 @@
+# WAITING-FOR-001: Registry content propagation to live KV
+
+**Status:** Open
+**Date identified:** 2026-04-30
+**Date resolved:** —
+**Type:** Decision
+
+## Waiting for
+
+KV deploy chain to be repaired so that registry changes accumulated in `main` since 2026-04-30 can reach the live resolver. Specifically:
+
+- 14 new CSAF advisory namespaces (provider entries created during research push)
+- 5 updated existing CSAF entries
+- Format metadata fields (`parsability`, `schema`, `parsing_instructions`, `auth`) added across all URL objects in the registry
+
+## Why waiting
+
+The technical fix path is documented in [FRICTION-001](../FRICTION/FRICTION-001.md). Until that's resolved, attempting to push the new content into KV via partial workarounds (e.g., manual `wrangler kv key put` for individual entries) would create a more confusing state than waiting:
+
+- We'd have a hand-edited subset of KV inconsistent with what the deploy chain produces
+- The next successful auto-sync would either overwrite the manual edits or (worse, in `--sync` mode with `--delete-orphans`) start deleting keys we hand-edited
+- Auditing what's actually live would require diffing the JSON files against KV manually, which is exactly the work the auto-deploy was built to avoid
+
+The right call is to fix the deploy chain end-to-end and let one clean sync land everything that's queued up.
+
+## Trigger
+
+Specific, observable: `gh run list --workflow=registry-kv-upload.yml --limit 1 -R CloudSecurityAlliance/SecID-Service` shows `success` for a recent run, AND a spot check on a known-changed entry returns the updated data:
+
+```bash
+curl 'https://secid.cloudsecurityalliance.org/api/v1/resolve?secid=secid:advisory/<one-of-the-14-new-CSAF-providers>'
+```
+
+returns a non-404 result.
+
+## Next action
+
+When triggered:
+
+1. Verify the 14 new CSAF entries resolve correctly via the live resolver
+2. Verify the 5 updated CSAF entries return their updated data (not stale cached values)
+3. Verify format metadata fields (`parsability`, `schema`, `parsing_instructions`, `auth`) appear in resolver responses
+4. Update [project_format_metadata.md](file:///Users/kurt/.claude/projects/-Volumes-MacMiniData-Users-kurt-GitHub-CloudSecurityAlliance-SecID/memory/project_format_metadata.md) memory entry with "deployed to production" status
+5. Mark this entry **Resolved**
+
+## Related
+
+- [FRICTION-001](../FRICTION/FRICTION-001.md) — the underlying deploy chain breakage
+- [OPERATIONAL-RESOURCES.md](../OPERATIONAL-RESOURCES.md) — deploy chain as an operational resource


### PR DESCRIPTION
## Summary

Lands the CINO-Project-Management plugin's mandatory artifacts for a project that runs operational infrastructure.

- **README.md:** Add `project_tracker_record:` provenance block (`recJ2sF2CudDqTJRN`). Update 700+ → 724 namespace count.
- **OPERATIONAL-RESOURCES.md (new, mandatory):** Worker, `secid_REGISTRY` KV, `secid_OBSERVABILITY` KV, two-stage GitHub Actions deploy chain, DNS. Per-resource health checks, runbooks, next-review dates.
- **BACKUP-RESOURCES.md (new):** Registry data (Git-backed via SecID repo), observability data (intentionally not backed up), DNS (CSA-Backups-CloudFlare), Worker code (Git), GitHub Actions secrets.
- **FRICTION.md + FRICTION/FRICTION-001.md (new):** KV deploy chain blocked since 2026-04-30 — Stage 1 (`SECID_TO_SERVICE_DISPATCH` token unauthorized) and Stage 2 (`cve-schema` Vitest failures) both blocking. Reproduction, root-cause hypotheses, 7-step resolution plan.
- **WAITING-FOR.md + WAITING-FOR/WAITING-FOR-001.md (new):** Registry content propagation to live KV. Trigger: `gh run list --workflow=registry-kv-upload.yml --limit 1` shows `success` AND a spot-check resolves a known-changed entry.

Part of a coordinated alignment across the four SecID repos. Companion PRs in SecID, SecID-Server-API, SecID-Client-SDK.

## Test plan

- [ ] README renders with metadata block above the title; namespace count reads 724
- [ ] OPERATIONAL-RESOURCES.md and BACKUP-RESOURCES.md render cleanly with all internal links resolving
- [ ] FRICTION-001 and WAITING-FOR-001 cross-link to each other and to OPERATIONAL-RESOURCES.md
- [ ] No broken external links (CSA-Backups-CloudFlare, CSA-Backups-GitHub repos exist)
- [ ] FRICTION-001 reproduction steps remain accurate when tested with current GH Actions state

🤖 Generated with [Claude Code](https://claude.com/claude-code)