### PR TITLE
Refresh docs: deploy chain resolved; update namespace counts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ npx tsx scripts/upload-registry-kv.ts --sync /path/to/SecID            # apply
 - **Account:** `f3898058ae0b4c20c692bbfa5b9b44b0` (Kseifried@cloudsecurityalliance.org's Account)
 - **Worker route:** `secid.cloudsecurityalliance.org/*` (zone `cloudsecurityalliance.org`)
 - **KV namespaces:**
-  - `secid_REGISTRY` (id `cfbc271787614516a39fa43d9ca4f95a`) — registry data, ~700+ keys
+  - `secid_REGISTRY` (id `cfbc271787614516a39fa43d9ca4f95a`) — registry data, ~1,150 keys
   - `secid_OBSERVABILITY` (id `c5cbc52b9a724433b3043efdf31857f4`) — error logging
 
 ## Deploy Chain

--- a/FRICTION.md
+++ b/FRICTION.md
@@ -4,4 +4,4 @@ Friction log for SecID-Service. Each entry is work that shouldn't be as hard as 
 
 | ID | Title | Status | Type | Date |
 |----|-------|--------|------|------|
-| [FRICTION-001](FRICTION/FRICTION-001.md) | KV deploy chain blocked | Open | Process overhead | 2026-04-30 |
+| [FRICTION-001](FRICTION/FRICTION-001.md) | KV deploy chain blocked | Resolved 2026-05-13 | Process overhead | 2026-04-30 |

--- a/FRICTION/FRICTION-001.md
+++ b/FRICTION/FRICTION-001.md
@@ -1,9 +1,30 @@
 # FRICTION-001: KV deploy chain blocked
 
-**Status:** Open
+**Status:** Resolved
 **Date identified:** 2026-04-30
-**Date resolved:** —
+**Date resolved:** 2026-05-13 (verified healthy)
 **Type:** Process overhead
+
+## Resolution
+
+The deploy chain is verified healthy as of 2026-05-13. Both stages now run successfully:
+
+- **Stage 1** (`Notify registry update` on SecID): 5+ successful runs 2026-05-12 through 2026-05-14
+- **Stage 2** (`Upload registry to KV` on SecID-Service): 8+ successful runs in the same window, all firing as `registry-updated` dispatches
+
+End-to-end verification on 2026-05-13:
+- `secid:control/iso.org/27017` (merged 2026-05-10) — live with full data
+- `secid:control/aicpa.org/tsc#CC6.1` (merged 2026-05-13) — live with descriptive group data
+- `secid:disclosure/silabs.com/cna` — overlay-injected `_broken_*` annotations from PR #4 present in response
+
+Registry has grown from ~700 namespaces (at time of friction filing) to 1,151 as of 2026-05-17, all propagated cleanly. Verification commands are documented in [SecID/CLAUDE.md "Checking deploy-chain health"](https://github.com/CloudSecurityAlliance/SecID/blob/main/CLAUDE.md#cicd) so future friction recurrences can be diagnosed faster.
+
+Specific fix path that resolved Stage 1 + Stage 2 is not captured here in detail (predates this update); see git history of `.github/workflows/` and any recent token-rotation work.
+
+---
+
+## Original description (preserved as record)
+
 
 ## Description
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Add SecID to your AI assistant as a remote MCP server:
 https://secid.cloudsecurityalliance.org/mcp
 ```
 
-That's it. No API keys, no local install, no configuration. Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP client that supports remote servers. Your AI assistant gets three tools (`resolve`, `lookup`, `describe`) and can immediately look up CVEs, CWEs, ATT&CK techniques, NIST controls, and 724 other security knowledge sources.
+That's it. No API keys, no local install, no configuration. Works with Claude Desktop, Claude Code, Cursor, Windsurf, and any MCP client that supports remote servers. Your AI assistant gets three tools (`resolve`, `lookup`, `describe`) and can immediately look up CVEs, CWEs, ATT&CK techniques, NIST controls, and 1,150+ other security knowledge sources.
 
 **Other ways to use SecID:** [Claude Code plugin](https://github.com/CloudSecurityAlliance/SecID/tree/main/plugins/secid) (local MCP server, supports internal resolvers) | [Client SDKs](https://github.com/CloudSecurityAlliance/SecID-Client-SDK) (Python, TypeScript, Go) | REST API (below)
 
@@ -66,7 +66,7 @@ No authentication. CORS enabled.
 
 - **Runtime:** Cloudflare Workers
 - **Framework:** Hono + @modelcontextprotocol/sdk
-- **Registry:** Compiled from [SecID](https://github.com/CloudSecurityAlliance/SecID) registry JSON files (700+ namespaces, 10 types)
+- **Registry:** Compiled from [SecID](https://github.com/CloudSecurityAlliance/SecID) registry JSON files (1,150+ namespaces, 10 types)
 - **Website:** Astro static site served from the same Worker
 
 ## Planned: also runs under the CSA MCP Server front door

--- a/WAITING-FOR.md
+++ b/WAITING-FOR.md
@@ -4,4 +4,4 @@ Strategic-waiting log for SecID-Service. Each entry has a specific trigger that 
 
 | ID | Title | Status | Type | Date |
 |----|-------|--------|------|------|
-| [WAITING-FOR-001](WAITING-FOR/WAITING-FOR-001.md) | Registry content propagation to live KV | Open | Decision | 2026-04-30 |
+| [WAITING-FOR-001](WAITING-FOR/WAITING-FOR-001.md) | Registry content propagation to live KV | Resolved 2026-05-13 | Decision | 2026-04-30 |

--- a/WAITING-FOR/WAITING-FOR-001.md
+++ b/WAITING-FOR/WAITING-FOR-001.md
@@ -1,9 +1,20 @@
 # WAITING-FOR-001: Registry content propagation to live KV
 
-**Status:** Open
+**Status:** Resolved
 **Date identified:** 2026-04-30
-**Date resolved:** —
+**Date resolved:** 2026-05-13 (verified working)
 **Type:** Decision
+
+## Resolution
+
+Deploy chain verified healthy on 2026-05-13. Recent successful runs of "Notify registry update" (SecID) and "Upload registry to KV" (SecID-Service) — chain operating normally and registry content reaching the live resolver. Verification commands documented in [SecID/CLAUDE.md "Checking deploy-chain health"](https://github.com/CloudSecurityAlliance/SecID/blob/main/CLAUDE.md#cicd).
+
+Live resolves confirm recent merges are propagating end-to-end:
+- `secid:control/iso.org/27017` — ISO 27017:2015 entry (merged 2026-05-10) returns full data
+- `secid:control/aicpa.org/tsc#CC6.1` — AICPA TSC entry (merged 2026-05-13) returns CC group data
+- `secid:disclosure/silabs.com/cna` — overlay-injected `_broken_*` annotations (from PR #4 work) present in response
+
+The registry has grown from ~700 namespaces at the time this WAITING-FOR was filed to 1,151 namespaces as of 2026-05-17, all propagated cleanly.
 
 ## Waiting for
 


### PR DESCRIPTION
## Summary

Three doc updates to bring SecID-Service in sync with current state:

1. **FRICTION-001 (KV deploy chain blocked) marked Resolved** as of 2026-05-13
2. **WAITING-FOR-001 (registry content propagation) marked Resolved** as of 2026-05-13
3. **Namespace counts updated** from 724/700+ to current 1,150+/1,151

## Why

### Deploy chain resolution

FRICTION-001 was filed 2026-04-30 documenting two stacked failures (Stage 1 PAT auth failure, Stage 2 cve-schema test failures). Both have been fixed for over a week. Recent successful runs:

- 'Notify registry update' (SecID side): 5+ successful runs 2026-05-12 through 2026-05-14
- 'Upload registry to KV' (this repo): 8+ successful runs in the same window, firing as \`registry-updated\` dispatches

End-to-end propagation verified:
- \`secid:control/iso.org/27017\` (merged 2026-05-10) — live with full data
- \`secid:control/aicpa.org/tsc#CC6.1\` (merged 2026-05-13) — live
- \`secid:disclosure/silabs.com/cna\` — overlay-injected \`_broken_*\` annotations from PR #4 work present in live response

### Namespace count growth

Registry has grown from 725 namespaces (when FRICTION-001 was filed) to 1,151 as of today — mostly from long-tail infosec, sector, and licensed-publisher namespace additions on the SecID repo over the past two weeks. README.md and CLAUDE.md hardcoded \"724\" / \"700+\" mentions updated.

## Test plan

- [x] Verified live resolves for recently-merged content
- [x] Spot-checked workflow run history on both SecID and SecID-Service
- [x] FRICTION-001 description preserved as a record (only status header + resolution-summary block updated)
- [x] WAITING-FOR-001 preserved similarly
- [x] No code changes; documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)