### PR TITLE
website: render subtype badges in resolver

### DIFF
--- a/website/src/components/Resolver.astro
+++ b/website/src/components/Resolver.astro
@@ -895,8 +895,34 @@
             item.appendChild(exDiv);
           }
 
+          // Subtype — array of named sub-classifications. See SecID/docs/reference/TYPES-AND-SUBTYPES.md
+          if (Array.isArray(d.subtype) && (d.subtype as unknown[]).length > 0) {
+            const sDiv = document.createElement("div");
+            sDiv.style.marginTop = "0.3rem";
+            sDiv.style.fontSize = "0.8rem";
+            sDiv.style.color = "var(--fg-muted)";
+            const sLabel = document.createElement("span");
+            sLabel.textContent = "Subtype: ";
+            sLabel.style.fontWeight = "600";
+            sDiv.appendChild(sLabel);
+            for (const v of d.subtype as unknown[]) {
+              if (typeof v !== "string") continue;
+              const badge = document.createElement("span");
+              badge.textContent = v;
+              badge.style.display = "inline-block";
+              badge.style.padding = "0.05rem 0.4rem";
+              badge.style.marginRight = "0.3rem";
+              badge.style.borderRadius = "3px";
+              badge.style.background = "var(--bg-elevated, #eee)";
+              badge.style.fontFamily = "monospace";
+              badge.style.fontSize = "0.75rem";
+              sDiv.appendChild(badge);
+            }
+            item.appendChild(sDiv);
+          }
+
           // Remaining data fields not yet rendered — show as key: value
-          const rendered = new Set(["official_name", "common_name", "description", "scope", "note", "notes", "urls", "contacts", "patterns", "examples", "weight", "source_count", "child_count"]);
+          const rendered = new Set(["official_name", "common_name", "description", "scope", "note", "notes", "urls", "contacts", "patterns", "examples", "weight", "source_count", "child_count", "subtype"]);
           for (const [key, val] of Object.entries(d)) {
             if (rendered.has(key) || val == null) continue;
             if (typeof val === "object") continue; // skip complex objects
@@ -1097,6 +1123,29 @@
                 const p = document.createElement("p");
                 p.textContent = d.description as string;
                 detail.appendChild(p);
+              }
+              if (Array.isArray(d.subtype) && (d.subtype as unknown[]).length > 0) {
+                const sDiv = document.createElement("div");
+                sDiv.style.marginTop = "0.3rem";
+                sDiv.style.fontSize = "0.8rem";
+                const sLabel = document.createElement("span");
+                sLabel.textContent = "Subtype: ";
+                sLabel.style.fontWeight = "600";
+                sDiv.appendChild(sLabel);
+                for (const v of d.subtype as unknown[]) {
+                  if (typeof v !== "string") continue;
+                  const badge = document.createElement("span");
+                  badge.textContent = v;
+                  badge.style.display = "inline-block";
+                  badge.style.padding = "0.05rem 0.4rem";
+                  badge.style.marginRight = "0.3rem";
+                  badge.style.borderRadius = "3px";
+                  badge.style.background = "var(--bg-elevated, #eee)";
+                  badge.style.fontFamily = "monospace";
+                  badge.style.fontSize = "0.75rem";
+                  sDiv.appendChild(badge);
+                }
+                detail.appendChild(sDiv);
               }
               if (d.examples && Array.isArray(d.examples)) {
                 const exH4 = document.createElement("h4");


### PR DESCRIPTION
The SecID registry now carries \`data.subtype\` as an array of named sub-classifications on source-level match_nodes — 43 methodology entries tagged plus glossary references. See SecID's [docs/reference/TYPES-AND-SUBTYPES.md](https://github.com/CloudSecurityAlliance/SecID/blob/main/docs/reference/TYPES-AND-SUBTYPES.md) for the catalog.

## The bug

The resolver returns the field correctly (\`curl ... | jq .results[0].data.subtype → [\"scoring\"]\`), but the website's Resolver component had a generic fallback for unknown data fields that explicitly skipped objects (\`if (typeof val === \"object\") continue\`) — which includes arrays. So subtype arrays were silently dropped from the human-facing page.

## The fix

Two surgical render paths for \`data.subtype\`:

1. **Main resolve view** (\`renderResponse\`): inline subtype badges before the generic key:value fallback
2. **Explorer leaf detail card**: same badge treatment after description, before examples

Badge styling: monospace text on a muted-background chip, multiple values rendered as adjacent chips. Matches the existing patterns/examples visual style.

The fallback's rendered-fields set also adds \`\"subtype\"\` so the generic loop doesn't double-render it.

## Test plan

- [x] \`npm run build\` clean (no TypeScript errors, no Astro warnings)
- [x] \`Subtype:\` label appears 2x in the bundled JS as expected
- [ ] After merge + deploy: visit https://secid.cloudsecurityalliance.org/resolve?secid=secid:methodology/first.org/cvss and confirm a \`Subtype: scoring\` chip renders under the entry
- [ ] Visit the explorer view for methodology and confirm leaf-level entries show subtype badges
- [ ] Multi-value spot-check: once a methodology gets tagged with 2 values, confirm both chips render side-by-side

## Follow-ups (not in this PR)

- Filter UI to show "all entries with subtype X" — would close the loop on the cross-source-discovery affordance documented in SecID's TYPES-AND-SUBTYPES.md
- Type-card descriptions on the homepage could mention subtypes where applicable (e.g., methodology card → "11 categories: scoring, mapping, threat modeling, ...")

🤖 Generated with [Claude Code](https://claude.com/claude-code)