### PR TITLE
homepage: list subtypes on methodology and reference type cards

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -111,11 +111,29 @@ secid:control/nist.gov/800-53@r5#AC-1
       <div class="type-card">
         <h3><a href="/resolve?secid=secid:methodology" class="type-link">methodology</a></h3>
         <p>Formal processes — scoring, mapping, risk assessment, threat modeling</p>
+        <div class="type-subtypes">
+          <span class="subtypes-label">Subtypes:</span>
+          <code class="subtype-chip">mapping</code>
+          <code class="subtype-chip">scoring</code>
+          <code class="subtype-chip">risk-management</code>
+          <code class="subtype-chip">vulnerability-management</code>
+          <code class="subtype-chip">threat-modeling</code>
+          <code class="subtype-chip">security-testing</code>
+          <code class="subtype-chip">digital-forensics</code>
+          <code class="subtype-chip">incident-management</code>
+          <code class="subtype-chip">supply-chain</code>
+          <code class="subtype-chip">audit-certification</code>
+          <code class="subtype-chip">classification</code>
+        </div>
         <code>secid:methodology/first.org/cvss@4.0</code>
       </div>
       <div class="type-card">
         <h3><a href="/resolve?secid=secid:reference" class="type-link">reference</a></h3>
         <p>Documents, research, identifier systems — arXiv, DOI, RFCs, CSA artifacts</p>
+        <div class="type-subtypes">
+          <span class="subtypes-label">Subtypes:</span>
+          <code class="subtype-chip">glossary</code>
+        </div>
         <code>secid:reference/ietf.org/rfc#RFC-9110</code>
       </div>
       <div class="type-card">
@@ -262,6 +280,26 @@ secid:control/nist.gov/800-53@r5#AC-1
   .type-card code {
     font-size: 0.75rem;
     word-break: break-all;
+  }
+  .type-subtypes {
+    font-size: 0.75rem;
+    color: var(--fg-muted);
+    margin-bottom: 0.5rem;
+    line-height: 1.5;
+  }
+  .type-subtypes .subtypes-label {
+    font-weight: 600;
+    margin-right: 0.25rem;
+  }
+  .type-subtypes .subtype-chip {
+    display: inline-block;
+    padding: 0.05rem 0.4rem;
+    margin-right: 0.25rem;
+    margin-bottom: 0.15rem;
+    border-radius: 3px;
+    background: var(--bg-elevated, #eee);
+    font-size: 0.7rem;
+    word-break: keep-all;
   }
   .type-card h3 a {
     color: inherit;


### PR DESCRIPTION
Follow-up to #6 — surfaces \`data.subtype\` values on the homepage type grid.

## What

Adds a \"Subtypes:\" line with chip-styled values to two cards in the \"Ten Types of Security Knowledge\" grid:

- **methodology**: 11 chips (\`mapping\`, \`scoring\`, \`risk-management\`, \`vulnerability-management\`, \`threat-modeling\`, \`security-testing\`, \`digital-forensics\`, \`incident-management\`, \`supply-chain\`, \`audit-certification\`, \`classification\`)
- **reference**: 1 chip (\`glossary\`)

The other 8 type cards remain unchanged — they have no named subtypes in the registry today (some have anticipated or implicit overloads documented in SecID's [TYPES-AND-SUBTYPES.md](https://github.com/CloudSecurityAlliance/SecID/blob/main/docs/reference/TYPES-AND-SUBTYPES.md) but no \`subtype:\` field on entries yet).

## Why

Without this, the only way to discover \"what subtypes exist within methodology\" is to drill into individual entries or read the registry docs. Surfacing them on the homepage matches the discoverability bar set by listing the 10 types in the first place.

## Visual style

Matches the badge style I shipped in #6 for the Resolver view — monospace text on a muted background chip, small radius, wrapping naturally on narrow viewports. Sits between the description and the example SecID code on each card.

## Maintenance

The chip list is hardcoded — same pattern as the type list itself and \`TYPE_DESCRIPTIONS\` in Resolver.astro. When new subtypes are added (always coordinated with a SecID PR updating TYPES-AND-SUBTYPES.md), the homepage update is a one-line addition.

## Test plan

- [x] \`npm run build\` clean
- [x] All 12 subtype values present in built \`dist/index.html\`
- [ ] After merge + deploy: visit https://secid.cloudsecurityalliance.org/ and confirm the methodology card shows 11 subtype chips and the reference card shows 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)