### PR TITLE
type-registry: single source of truth + /api/v1/types + KV subtype counts

### DIFF
--- a/scripts/upload-registry-kv.ts
+++ b/scripts/upload-registry-kv.ts
@@ -7,6 +7,7 @@
  *   - secid:*                   — GlobalIndex: combined child_index across all types (×1)
  *   - secid:registry            — complete compiled Registry (×1)
  *   - secid:meta                — version/counts metadata (×1)
+ *   - secid:subtypes            — per-type, per-subtype match_node counts (×1)
  *
  * Usage:
  *   npx tsx scripts/upload-registry-kv.ts [path-to-secid-repo]
@@ -204,6 +205,9 @@ function buildEntries(): BulkEntry[] {
   // secid:{type} — TypeIndex with child_index
   const types = Object.keys(registry).sort();
   const typeCounts: Record<string, number> = {};
+  // Per-type, per-subtype match_node counts. Populated in the same walk as child_index
+  // so the registry only gets traversed once. Served via /api/v1/types.
+  const subtypeCounts: Record<string, Record<string, number>> = {};
 
   for (const type of types) {
     const namespaces = Object.entries(registry[type])
@@ -222,6 +226,20 @@ function buildEntries(): BulkEntry[] {
     for (const [ns, data] of Object.entries(registry[type])) {
       if (!data.match_nodes) continue;
       for (const node of data.match_nodes) {
+        // Subtype tags live on source-level match_nodes. Each is an array of
+        // string values per TYPES-AND-SUBTYPES.md. Tolerate single-string for
+        // safety even though the convention is array-only.
+        const rawSubtype = (node.data as Record<string, unknown> | undefined)?.subtype;
+        const subtypeValues = Array.isArray(rawSubtype)
+          ? rawSubtype.filter((v): v is string => typeof v === "string")
+          : typeof rawSubtype === "string"
+            ? [rawSubtype]
+            : [];
+        for (const v of subtypeValues) {
+          subtypeCounts[type] ??= {};
+          subtypeCounts[type][v] = (subtypeCounts[type][v] ?? 0) + 1;
+        }
+
         const nameSlug = extractNameSlug(node);
         if (!node.children) continue;
         for (const child of node.children) {
@@ -298,6 +316,14 @@ function buildEntries(): BulkEntry[] {
       total_namespaces: count,
       types: typeCounts,
     }),
+  });
+
+  // secid:subtypes — per-type, per-subtype match_node counts. Served by /api/v1/types
+  // merged with the bundled type-registry constant. Types with zero subtype-tagged
+  // entries simply have no entry in the outer record.
+  entries.push({
+    key: "secid:subtypes",
+    value: JSON.stringify(subtypeCounts),
   });
 
   console.log(`Built ${entries.length} KV entries from ${count} namespaces:`);

--- a/src/api.ts
+++ b/src/api.ts
@@ -3,9 +3,48 @@ import { resolveFromKV } from "./kv-resolve";
 import { RegistryContext } from "./kv-registry";
 import type { AppEnv } from "./types";
 import { buildErrorEntry, recordError } from "./observability";
+import { TYPE_REGISTRY } from "./type-registry";
 
 const MAX_SECID_QUERY_CHARS = 1024;
 const MAX_KV_VALUE_BYTES = 25 * 1024 * 1024; // 25 MiB (Cloudflare KV max value size)
+
+/**
+ * Returns the canonical list of SecID types and their named subtypes, merged
+ * with per-(type, subtype) entry counts when available.
+ *
+ * Types and subtypes are served from the bundled type-registry constant —
+ * zero KV reads, zero latency. Counts come from the secid:subtypes KV key
+ * populated at upload time (and from secid:meta for top-level type counts).
+ * If either KV key is missing, the response still returns the type/subtype
+ * structure with counts omitted or zero.
+ */
+export async function handleTypes(c: Context<AppEnv>): Promise<Response> {
+  const kv = c.env.secid_REGISTRY;
+  let typeCounts: Record<string, number> = {};
+  let subtypeCounts: Record<string, Record<string, number>> = {};
+  if (kv) {
+    const ctx = new RegistryContext(kv);
+    const [meta, subtypes] = await Promise.all([
+      ctx.getMeta().catch(() => null),
+      ctx.getSubtypeCounts().catch(() => null),
+    ]);
+    if (meta?.types) typeCounts = meta.types;
+    if (subtypes) subtypeCounts = subtypes;
+  }
+  return c.json({
+    types: TYPE_REGISTRY.map((t) => ({
+      type: t.type,
+      description: t.short,
+      long_description: t.long,
+      namespace_count: typeCounts[t.type] ?? null,
+      subtypes: t.subtypes.map((s) => ({
+        value: s.value,
+        description: s.description,
+        count: subtypeCounts[t.type]?.[s.value] ?? null,
+      })),
+    })),
+  });
+}
 
 export async function handleRegistryDownload(
   c: Context<AppEnv>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { handleResolve, handleRegistryDownload } from "./api";
+import { handleResolve, handleRegistryDownload, handleTypes } from "./api";
 import { handleMCP } from "./mcp";
 import type { AppEnv } from "./types";
 import { buildErrorEntry, recordError } from "./observability";
@@ -28,6 +28,7 @@ app.onError(async (err, c) => {
 
 app.get("/api/v1/resolve", handleResolve);
 app.get("/api/v1/registry.json", handleRegistryDownload);
+app.get("/api/v1/types", handleTypes);
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 

--- a/src/kv-registry.ts
+++ b/src/kv-registry.ts
@@ -3,6 +3,7 @@ import type {
   Registry,
   RegistryMeta,
   RegistryNamespace,
+  SubtypeCounts,
   TypeIndex,
 } from "./types";
 
@@ -82,5 +83,15 @@ export class RegistryContext {
 
   async getMeta(): Promise<RegistryMeta | null> {
     return this.kv.get<RegistryMeta>("secid:meta", "json");
+  }
+
+  /**
+   * Returns per-type, per-subtype counts as computed by the KV upload script.
+   * Returns null if the key isn't populated (e.g., older deploys before the
+   * subtype-counting upload script shipped). Callers should treat null as
+   * "counts unavailable" and fall back to zero or omit counts from responses.
+   */
+  async getSubtypeCounts(): Promise<SubtypeCounts | null> {
+    return this.kv.get<SubtypeCounts>("secid:subtypes", "json");
   }
 }

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -7,9 +7,20 @@ import { SECID_TYPES } from "./types";
 import type { AppEnv } from "./types";
 import type { Context } from "hono";
 import { buildErrorEntry, recordError } from "./observability";
+import { TYPE_REGISTRY, TYPE_BY_NAME } from "./type-registry";
 
 const MAX_SECID_QUERY_CHARS = 1024;
 const MAX_MCP_BODY_BYTES = 64 * 1024; // 64 KB
+
+// One-line summary of all 10 types — used to keep prompt descriptions in sync
+// with the canonical type-registry without manual duplication. Format:
+// "type1 (examples), type2 (examples), ..."
+// Falls back gracefully if a short description doesn't follow the " — examples" convention.
+const TYPES_INLINE = TYPE_REGISTRY.map((t) => {
+  const dashIdx = t.short.indexOf(" — ");
+  const examples = dashIdx !== -1 ? t.short.slice(dashIdx + 3) : t.short;
+  return `${t.type} (${examples})`;
+}).join(", ");
 
 // ── Documentation resources ──
 // These are MCP resources containing instructions for building SecID clients.
@@ -337,7 +348,7 @@ RESPONSE: Same format as resolve — { secid_query, status, results[], message? 
 Results from different sources will have different secid values showing where each match was found.
 Sort by weight descending — highest weight is the most authoritative source.
 
-TYPES: advisory (CVEs, vendor advisories), weakness (CWE, OWASP), ttp (ATT&CK, CAPEC), control (NIST, ISO), capability (product security features — encryption, logging, access control), methodology (scoring, mapping, risk assessment — CVSS, SSVC, IR 8477), disclosure (CVE CNAs, PSIRTs, vulnerability reporting — 502 CVE Program partners with scope, contacts, policy), regulation (GDPR, HIPAA), entity (orgs, products), reference (RFCs, arXiv, DOI)`;
+TYPES: ${TYPES_INLINE}`;
 
 const DESCRIBE_DESCRIPTION = `Get registry metadata about a SecID source, namespace, or type — without resolving a specific item.
 
@@ -505,8 +516,23 @@ function createMcpServer(
         const hashIdx = secid.indexOf("#");
         const describeInput = hashIdx !== -1 ? secid.slice(0, hashIdx) : secid;
         const result = await resolveFromKV(registryKv, describeInput);
+
+        // Bare-type query (secid:<type>): augment response with declared subtypes
+        // from the type-registry. Lets MCP clients discover what subtypes exist
+        // without an extra round-trip to /api/v1/types.
+        const bareType = (() => {
+          const stripped = describeInput.startsWith("secid:") ? describeInput.slice(6) : describeInput;
+          if (stripped.includes("/")) return null;
+          const cleaned = stripped.split("@")[0].split("?")[0];
+          return TYPE_BY_NAME[cleaned] ? cleaned : null;
+        })();
+
+        const responsePayload: unknown = bareType
+          ? { ...(result as unknown as Record<string, unknown>), subtypes: TYPE_BY_NAME[bareType]!.subtypes }
+          : result;
+
         return {
-          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          content: [{ type: "text", text: JSON.stringify(responsePayload, null, 2) }],
         };
       } catch (err) {
         const entry = buildErrorEntry("mcp.tool.describe", secid, err, req);
@@ -532,7 +558,7 @@ function createMcpServer(
   server.resource(
     "registry",
     "secid://registry",
-    { description: "Full listing of all SecID types and their namespace counts. SecID covers 10 types: advisory (CVEs, vendor advisories), weakness (CWE, OWASP), ttp (ATT&CK, CAPEC), control (NIST, ISO), capability (product security features — encryption, logging, access control), methodology (scoring, mapping, risk assessment — CVSS, SSVC, IR 8477), disclosure (CVE CNAs, PSIRTs, bug bounties), regulation (GDPR, HIPAA), entity (orgs, products), reference (RFCs, arXiv, DOI). 700+ namespaces total." },
+    { description: `Full listing of all SecID types and their namespace counts. SecID covers ${TYPE_REGISTRY.length} types: ${TYPES_INLINE}. 700+ namespaces total.` },
     async () => {
       const listing: Record<string, number> = {};
       const ctx = new RegistryContext(registryKv);

--- a/src/type-registry.ts
+++ b/src/type-registry.ts
@@ -1,0 +1,138 @@
+// ── SecID Type Registry ──
+//
+// SINGLE SOURCE OF TRUTH for SecID types and their named subtypes.
+//
+// Imported by Worker code (api.ts, mcp.ts), the homepage (index.astro), and the
+// Resolver component (Resolver.astro). When a type or subtype is added, removed,
+// or its description changes, this file is the only place that needs editing —
+// other code reads from this constant.
+//
+// IMPORTANT — changes to this file are a big deal:
+//   * Adding/removing a type is a spec-level event requiring coordinated changes
+//     across SecID, SecID-Service, SecID-Server-API, and SecID-Client-SDK.
+//   * Adding a subtype is a registry-level event requiring a corresponding
+//     SecID PR that updates docs/reference/TYPES-AND-SUBTYPES.md.
+//   * The SecID repo's CI validates that every `subtype:` value used in
+//     registry data is declared here. Drift is caught at PR time.
+//
+// See SecID's docs/reference/TYPES-AND-SUBTYPES.md for the conceptual model.
+
+export interface SubtypeDef {
+  /** The canonical kebab-case value used in registry data's `data.subtype` array. */
+  value: string;
+  /** One-sentence description for display in describe responses and the API. */
+  description: string;
+}
+
+export interface TypeDef {
+  /** Type name (matches the value in registry entries' `type` field). */
+  type: string;
+  /** Short human description for the homepage type card and resolver views. */
+  short: string;
+  /** Longer description used by the MCP describe tool. */
+  long: string;
+  /** Named subtypes declared for this type. Empty array if none. */
+  subtypes: readonly SubtypeDef[];
+}
+
+// Order is intentional — matches the visual ordering in registry/INDEX.md and
+// the homepage type-card grid.
+export const TYPE_REGISTRY: readonly TypeDef[] = [
+  {
+    type: "advisory",
+    short: "Vulnerability publications — CVEs, vendor advisories, GHSAs, incident reports",
+    long: "Publications about vulnerabilities — CVE records, GHSA advisories, vendor advisories, and incident reports (AIID, NHTSA, FDA adverse events). Both vuln advisories and incident reports answer 'this happened.'",
+    subtypes: [],
+  },
+  {
+    type: "capability",
+    short: "Product security features — AWS encryption, CloudTrail, Azure RBAC",
+    long: "Concrete product security features with configuration options, audit commands, and remediation instructions. Vendor-authoritative facts about what a product can do.",
+    subtypes: [],
+  },
+  {
+    type: "control",
+    short: "Security requirements — NIST CSF, ISO 27001, CCM, CIS Benchmarks",
+    long: "Normative security requirements — frameworks (NIST CSF, ISO 27001), control catalogs (CCM, AICM), benchmarks (CIS, HarmBench), and documentation standards (Model Cards). Defines what must be done or tested.",
+    subtypes: [],
+  },
+  {
+    type: "disclosure",
+    short: "Vulnerability disclosure programs, policies, reporting channels",
+    long: "Vulnerability disclosure programs — CVE Numbering Authorities, PSIRTs, bug bounty programs, security.txt entries, and policy documents. Tells researchers how and where to report.",
+    subtypes: [],
+  },
+  {
+    type: "entity",
+    short: "Organizations, products, services",
+    long: "Organizations (Microsoft, NIST, ISO), products (Office 365, AWS S3), and services. Identity records — cited as anchors by other types.",
+    subtypes: [],
+  },
+  {
+    type: "methodology",
+    short: "Formal processes — scoring, mapping, risk assessment, threat modeling",
+    long: "Formal processes with defined inputs, steps, and outputs — methodologies for scoring (CVSS, SSVC, EPSS), mapping (IR 8477, CTID), risk management (FAIR, ISO 27005), threat modeling (STRIDE, PASTA), and more.",
+    subtypes: [
+      { value: "mapping", description: "Methodologies that produce a mapping/crosswalk from one framework to another." },
+      { value: "scoring", description: "Methodologies that produce a score, prioritization decision, or rating." },
+      { value: "risk-management", description: "Methodologies for identifying, analyzing, evaluating, and treating risk." },
+      { value: "vulnerability-management", description: "Methodologies for receiving, handling, and disclosing vulnerabilities." },
+      { value: "threat-modeling", description: "Methodologies for systematically identifying threats against a system." },
+      { value: "security-testing", description: "Methodologies for conducting security tests and assessments." },
+      { value: "digital-forensics", description: "Methodologies for digital evidence collection, preservation, and analysis." },
+      { value: "incident-management", description: "Methodologies for detecting, handling, and analyzing security incidents." },
+      { value: "supply-chain", description: "Methodologies for software supply chain security." },
+      { value: "audit-certification", description: "Methodologies for conformity assessment and certification." },
+      { value: "classification", description: "Methodologies for classifying or labeling information for handling (e.g., TLP)." },
+    ],
+  },
+  {
+    type: "reference",
+    short: "Documents, research, identifier systems — arXiv, DOI, RFCs, CSA artifacts",
+    long: "Documents, research papers, and identifier systems — arXiv, DOI, ISBN, RFCs, and CSA artifacts. Citation targets without normative force.",
+    subtypes: [
+      { value: "glossary", description: "A glossary document with addressable term-level subpaths. Entry is identity-only; term data lives in a separate dataset repository." },
+    ],
+  },
+  {
+    type: "regulation",
+    short: "Laws and legal requirements — GDPR, HIPAA, PCI DSS",
+    long: "Laws, directives, and binding legal requirements — GDPR, HIPAA, NIS2, PSD2, and national transpositions of EU directives.",
+    subtypes: [],
+  },
+  {
+    type: "ttp",
+    short: "Adversary techniques — MITRE ATT&CK, ATLAS, CAPEC",
+    long: "Tactics, techniques, and procedures used by adversaries — MITRE ATT&CK (enterprise, mobile, ICS), ATLAS (AI attacks), and CAPEC.",
+    subtypes: [],
+  },
+  {
+    type: "weakness",
+    short: "Abstract flaw patterns — CWE, OWASP Top 10",
+    long: "Abstract weakness patterns — Common Weakness Enumeration (CWE) and OWASP Top 10 categories. Not specific vulnerabilities; classes of flaws.",
+    subtypes: [],
+  },
+] as const;
+
+// ── Derived helpers ──
+
+/** All 10 SecID type names in canonical order. */
+export const SECID_TYPES = TYPE_REGISTRY.map((t) => t.type) as readonly string[];
+
+/** Type alias — restrictive string union over the 10 declared types. */
+export type SecIDType = (typeof TYPE_REGISTRY)[number]["type"];
+
+/** Lookup map by type name. Returns undefined for unknown types. */
+export const TYPE_BY_NAME: Readonly<Record<string, TypeDef | undefined>> = Object.fromEntries(
+  TYPE_REGISTRY.map((t) => [t.type, t]),
+);
+
+/** All valid subtype values, keyed by type name. Used by CI validation. */
+export const SUBTYPES_BY_TYPE: Readonly<Record<string, readonly string[]>> = Object.fromEntries(
+  TYPE_REGISTRY.map((t) => [t.type, t.subtypes.map((s) => s.value)]),
+);
+
+/** Short-description-only map. Used by homepage cards and Resolver TYPE_DESCRIPTIONS. */
+export const TYPE_SHORT_DESCRIPTIONS: Readonly<Record<string, string>> = Object.fromEntries(
+  TYPE_REGISTRY.map((t) => [t.type, t.short]),
+);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,19 +1,10 @@
 // ── SecID Types ──
-// Valid SecID types as defined by the spec
-export const SECID_TYPES = [
-  "advisory",
-  "capability",
-  "control",
-  "disclosure",
-  "entity",
-  "methodology",
-  "reference",
-  "regulation",
-  "ttp",
-  "weakness",
-] as const;
-
-export type SecIDType = (typeof SECID_TYPES)[number];
+// Valid SecID types are defined by the type-registry (single source of truth).
+// Re-exported here so existing imports of `SECID_TYPES`/`SecIDType` from
+// "./types" keep working without churn across the codebase.
+import { SECID_TYPES as _SECID_TYPES, type SecIDType as _SecIDType } from "./type-registry";
+export const SECID_TYPES = _SECID_TYPES;
+export type SecIDType = _SecIDType;
 
 // ── Parsed SecID ──
 // Result of parsing a SecID string into components
@@ -183,6 +174,13 @@ export interface RegistryMeta {
   total_namespaces: number;
   types: Record<string, number>;
 }
+
+/**
+ * Per-type subtype counts. Outer key is type name, inner key is subtype value,
+ * value is the number of source-level match_nodes carrying that subtype.
+ * Populated at KV upload time by walking registry entries; served via /api/v1/types.
+ */
+export type SubtypeCounts = Record<string, Record<string, number>>;
 
 // ── App Environment ──
 // Cloudflare Worker bindings available via Hono context

--- a/website/src/components/Resolver.astro
+++ b/website/src/components/Resolver.astro
@@ -329,6 +329,11 @@
 </style>
 
 <script>
+  // Pull the short descriptions from the single source of truth so the
+  // explorer's type-grid stays in sync with the homepage and the MCP describe
+  // tool. See src/type-registry.ts.
+  import { TYPE_SHORT_DESCRIPTIONS as TYPE_DESCRIPTIONS_IMPORT } from "../../../src/type-registry";
+
   const form = document.getElementById("resolver-form") as HTMLFormElement;
   const input = document.getElementById("resolver-input") as HTMLInputElement;
   const output = document.getElementById("resolver-output") as HTMLDivElement;
@@ -383,18 +388,7 @@
   let explorerMode = false;
   let explorerPath: { label: string; secid: string | null }[] = [];
 
-  const TYPE_DESCRIPTIONS: Record<string, string> = {
-    advisory: "Vulnerability advisories, incident reports, and safety publications",
-    capability: "Product security features — configurations, audit commands, remediation",
-    control: "Security controls, frameworks, and benchmarks",
-    disclosure: "Vulnerability disclosure programs, policies, and reporting channels",
-    entity: "Vendors, products, and services",
-    methodology: "Formal processes — scoring (CVSS, SSVC), mapping (IR 8477), risk assessment (ISO 27005), threat modeling (STRIDE)",
-    reference: "Documents, research papers, and identifier systems",
-    regulation: "Laws, directives, and legal requirements",
-    ttp: "Attack patterns, adversary techniques, and procedures",
-    weakness: "Weakness taxonomies and abstract flaw patterns",
-  };
+  const TYPE_DESCRIPTIONS: Record<string, string> = TYPE_DESCRIPTIONS_IMPORT;
 
   // --- Example buttons fill the input and submit ---
   form.querySelectorAll("[data-example]").forEach((btn) => {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,5 +1,22 @@
 ---
 import Base from "../layouts/Base.astro";
+import { TYPE_REGISTRY } from "../../../src/type-registry";
+
+// Example SecID strings shown on each type card. Hardcoded here (not in
+// type-registry) because the registry is concerned with types/subtypes, not
+// homepage marketing examples.
+const TYPE_EXAMPLES: Record<string, string> = {
+  advisory: "secid:advisory/mitre.org/cve#CVE-2024-1234",
+  capability: "secid:capability/amazon.com/aws/s3#default-encryption",
+  control: "secid:control/nist.gov/csf@2.0#PR.AC-1",
+  disclosure: "secid:disclosure/redhat.com/cna",
+  entity: "secid:entity/microsoft.com/azure",
+  methodology: "secid:methodology/first.org/cvss@4.0",
+  reference: "secid:reference/ietf.org/rfc#RFC-9110",
+  regulation: "secid:regulation/europa.eu/gdpr#art-32",
+  ttp: "secid:ttp/mitre.org/attack#T1059.003",
+  weakness: "secid:weakness/mitre.org/cwe#CWE-79",
+};
 
 const apiExample = `GET /api/v1/resolve?secid=secid:advisory/mitre.org/cve%23CVE-2021-44228
 
@@ -81,76 +98,23 @@ secid:control/nist.gov/800-53@r5#AC-1
   </section>
 
   <section>
-    <h2>Ten Types of Security Knowledge</h2>
+    <h2>{TYPE_REGISTRY.length} Types of Security Knowledge</h2>
     <div class="type-grid">
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:advisory" class="type-link">advisory</a></h3>
-        <p>Vulnerability publications — CVEs, vendor advisories, GHSAs, incident reports</p>
-        <code>secid:advisory/mitre.org/cve#CVE-2024-1234</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:capability" class="type-link">capability</a></h3>
-        <p>Product security features — AWS encryption, CloudTrail, Azure RBAC</p>
-        <code>secid:capability/amazon.com/aws/s3#default-encryption</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:control" class="type-link">control</a></h3>
-        <p>Security requirements — NIST CSF, ISO 27001, CCM, CIS Benchmarks</p>
-        <code>secid:control/nist.gov/csf@2.0#PR.AC-1</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:disclosure" class="type-link">disclosure</a></h3>
-        <p>Vulnerability disclosure programs, policies, reporting channels</p>
-        <code>secid:disclosure/redhat.com/cna</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:entity" class="type-link">entity</a></h3>
-        <p>Organizations, products, services</p>
-        <code>secid:entity/microsoft.com/azure</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:methodology" class="type-link">methodology</a></h3>
-        <p>Formal processes — scoring, mapping, risk assessment, threat modeling</p>
-        <div class="type-subtypes">
-          <span class="subtypes-label">Subtypes:</span>
-          <code class="subtype-chip">mapping</code>
-          <code class="subtype-chip">scoring</code>
-          <code class="subtype-chip">risk-management</code>
-          <code class="subtype-chip">vulnerability-management</code>
-          <code class="subtype-chip">threat-modeling</code>
-          <code class="subtype-chip">security-testing</code>
-          <code class="subtype-chip">digital-forensics</code>
-          <code class="subtype-chip">incident-management</code>
-          <code class="subtype-chip">supply-chain</code>
-          <code class="subtype-chip">audit-certification</code>
-          <code class="subtype-chip">classification</code>
+      {TYPE_REGISTRY.map((t) => (
+        <div class="type-card">
+          <h3><a href={`/resolve?secid=secid:${t.type}`} class="type-link">{t.type}</a></h3>
+          <p>{t.short}</p>
+          {t.subtypes.length > 0 && (
+            <div class="type-subtypes">
+              <span class="subtypes-label">Subtypes:</span>
+              {t.subtypes.map((s) => (
+                <code class="subtype-chip">{s.value}</code>
+              ))}
+            </div>
+          )}
+          <code>{TYPE_EXAMPLES[t.type] ?? `secid:${t.type}`}</code>
         </div>
-        <code>secid:methodology/first.org/cvss@4.0</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:reference" class="type-link">reference</a></h3>
-        <p>Documents, research, identifier systems — arXiv, DOI, RFCs, CSA artifacts</p>
-        <div class="type-subtypes">
-          <span class="subtypes-label">Subtypes:</span>
-          <code class="subtype-chip">glossary</code>
-        </div>
-        <code>secid:reference/ietf.org/rfc#RFC-9110</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:regulation" class="type-link">regulation</a></h3>
-        <p>Laws and legal requirements — GDPR, HIPAA, PCI DSS</p>
-        <code>secid:regulation/europa.eu/gdpr#art-32</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:ttp" class="type-link">ttp</a></h3>
-        <p>Adversary techniques — MITRE ATT&CK, ATLAS, CAPEC</p>
-        <code>secid:ttp/mitre.org/attack#T1059.003</code>
-      </div>
-      <div class="type-card">
-        <h3><a href="/resolve?secid=secid:weakness" class="type-link">weakness</a></h3>
-        <p>Abstract flaw patterns — CWE, OWASP Top 10</p>
-        <code>secid:weakness/mitre.org/cwe#CWE-79</code>
-      </div>
+      ))}
     </div>
   </section>
 


### PR DESCRIPTION
Implements the type-registry architecture you specified: types/subtypes treated as a code-level decision (not a casual data edit), bundled into the Worker for zero-latency reads, with KV sync for counts and non-code consumers.

## What ships

### \`src/type-registry.ts\` (new) — authoritative constant
Single source of truth for the 10 types + their named subtypes. Imported by Worker code (api.ts, mcp.ts), the homepage (index.astro), and the Resolver component (Resolver.astro). Currently declares:
- **methodology** (11 subtypes): mapping, scoring, risk-management, vulnerability-management, threat-modeling, security-testing, digital-forensics, incident-management, supply-chain, audit-certification, classification
- **reference** (1 subtype): glossary
- 8 other types: no named subtypes today

### \`/api/v1/types\` — new endpoint
\`\`\`json
GET /api/v1/types
{
  \"types\": [
    {
      \"type\": \"methodology\",
      \"description\": \"Formal processes — scoring, mapping, risk assessment, threat modeling\",
      \"long_description\": \"...\",
      \"namespace_count\": 22,
      \"subtypes\": [
        {\"value\": \"mapping\", \"description\": \"...\", \"count\": 7},
        {\"value\": \"scoring\", \"description\": \"...\", \"count\": 7},
        ...
      ]
    },
    ...
  ]
}
\`\`\`
Types/subtypes served from the in-memory constant (zero KV reads). Counts merged from \`secid:meta\` and \`secid:subtypes\` KV keys. Missing KV gracefully degrades to \`null\` counts.

### KV subtype counts
\`scripts/upload-registry-kv.ts\` walks match_nodes once per upload, counts \`data.subtype\` occurrences per (type, value), writes \`secid:subtypes\` KV key. Tolerates array and legacy single-string forms.

### MCP describe enhancement
- \`TYPES:\` inline list and registry resource description computed from constant — no more hand-edited type-list strings
- \`describe('secid:methodology')\` now returns the declared subtypes list alongside the namespace listing, so MCP clients can discover subtypes without an extra round-trip

### Website unification
- Homepage type cards generated from TYPE_REGISTRY at build time (replaces 10 hand-rolled HTML blocks)
- Resolver's TYPE_DESCRIPTIONS imported from the constant instead of duplicated

## Paired SecID PR

A companion PR will land in CloudSecurityAlliance/SecID that adds CI validation: every \`subtype:\` value used in registry data must be declared here. Forces the code change first, gates drift at PR time.

## Test plan

- [x] \`npm run build\` clean (Astro/Vite + Worker)
- [x] \`npx tsc --noEmit\` clean for all src/ files (pre-existing script/test errors unchanged)
- [x] Bundle ships all 11 methodology subtype values and the glossary value
- [x] All 10 type cards still render on built homepage
- [ ] After merge + deploy: \`curl https://secid.cloudsecurityalliance.org/api/v1/types\` returns expected shape with counts
- [ ] MCP describe('secid:methodology') returns the augmented response with subtypes list

## Note on deploy

This repo has no auto-deploy on push-to-main; merging this PR doesn't ship to production. After merge, run:
\`\`\`
gh workflow run \"Upload registry to KV\" -R CloudSecurityAlliance/SecID-Service
\`\`\`
to deploy the Worker (which is what serves the website + API). Worth a follow-up issue to add a proper deploy.yml workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)