### PR TITLE
Search fix + subtype filter + auto-deploy on push to main

### DIFF
--- a/.github/workflows/registry-kv-upload.yml
+++ b/.github/workflows/registry-kv-upload.yml
@@ -1,8 +1,23 @@
 name: Upload registry to KV
 
+# Triggers:
+#   - repository_dispatch (registry-updated): fires when CloudSecurityAlliance/SecID
+#     merges a registry change. The dispatch is sent by SecID's update-registry.yml.
+#   - push to main: any merge into this repo (code, website, docs). The registry
+#     content fetched from the SecID repo will be whatever main currently has;
+#     a docs-only push to this repo still triggers a full registry sync + deploy
+#     because src/registry.ts is regenerated each run and the Worker bundles it.
+#   - workflow_dispatch: manual trigger from the gh CLI / Actions UI.
+#
+# Safety note: this workflow does NOT interpolate untrusted GitHub event data
+# (issue titles, PR bodies, commit messages, etc.) into shell commands. The
+# only template expansions are `${{ secrets.SECID_SERVICE_DEPLOY }}` for the
+# Cloudflare token, which is a repo secret, not user input.
 on:
   repository_dispatch:
     types: [registry-updated]
+  push:
+    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/scripts/upload-registry-kv.ts
+++ b/scripts/upload-registry-kv.ts
@@ -212,12 +212,27 @@ function buildEntries(): BulkEntry[] {
   for (const type of types) {
     const namespaces = Object.entries(registry[type])
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([ns, data]) => ({
-        namespace: ns,
-        official_name: data.official_name,
-        common_name: data.common_name,
-        source_count: data.match_nodes?.length ?? 0,
-      }));
+      .map(([ns, data]) => {
+        // Union of subtype values across all source-level match_nodes in this
+        // namespace. Included in the TypeIndex so /api/v1/resolve type-only
+        // queries can filter without re-fetching each namespace's full data.
+        const subtypes = new Set<string>();
+        for (const node of data.match_nodes ?? []) {
+          const raw = (node.data as Record<string, unknown> | undefined)?.subtype;
+          if (Array.isArray(raw)) {
+            for (const v of raw) if (typeof v === "string") subtypes.add(v);
+          } else if (typeof raw === "string") {
+            subtypes.add(raw);
+          }
+        }
+        return {
+          namespace: ns,
+          official_name: data.official_name,
+          common_name: data.common_name,
+          source_count: data.match_nodes?.length ?? 0,
+          subtypes: [...subtypes].sort(),
+        };
+      });
 
     typeCounts[type] = namespaces.length;
 
@@ -274,19 +289,36 @@ function buildEntries(): BulkEntry[] {
     });
   }
 
-  // secid:* — GlobalIndex: combined child_index across all types for bare identifier search
-  const globalChildIndex: Array<ChildIndexEntry & { type: string }> = [];
+  // secid:* — GlobalIndex: combined index across all types for bare identifier search.
+  // Indexes BOTH source-level patterns (so "cwe" finds weakness/mitre.org/cwe) AND
+  // child-level patterns (so "CVE-2021-44228" finds the specific record). Entries
+  // carry a `level` discriminator so the resolver can build the right ParsedSecID:
+  //   - level: "source" → fully-qualified resolution to that source's match_node
+  //   - level: "child"  → cross-source item lookup
+  const globalChildIndex: Array<ChildIndexEntry & { type: string; level: "source" | "child" }> = [];
   for (const type of types) {
     for (const [ns, data] of Object.entries(registry[type])) {
       if (!data.match_nodes) continue;
       for (const node of data.match_nodes) {
         const nameSlug = extractNameSlug(node);
+        // Source-level entry — match_node's own patterns (e.g., "(?i)^cwe$").
+        globalChildIndex.push({
+          type,
+          namespace: ns,
+          name_slug: nameSlug,
+          level: "source",
+          patterns: node.patterns,
+          description: node.description,
+          weight: node.weight ?? 100,
+          has_url: !!node.data?.url,
+        });
         if (!node.children) continue;
         for (const child of node.children) {
           globalChildIndex.push({
             type,
             namespace: ns,
             name_slug: nameSlug,
+            level: "child",
             patterns: child.patterns,
             description: child.description,
             weight: child.weight,

--- a/src/api.ts
+++ b/src/api.ts
@@ -123,6 +123,52 @@ export async function handleResolve(c: Context<AppEnv>): Promise<Response> {
       });
     }
     const result = await resolveFromKV(kv, decoded);
+
+    // Optional ?subtype= filter — applies to namespace listings within a type.
+    // Two response shapes need handling:
+    //   1. Type-only query (e.g., secid:methodology) returns a single wrapper
+    //      result whose data.namespaces is the array. Filter that inner array.
+    //   2. Other listings (cross-source, list-by-namespace) return per-entry
+    //      results with data.subtypes per result. Filter the top-level array.
+    // Item resolutions and source-description responses pass through untouched.
+    const subtypeFilter = c.req.query("subtype");
+    if (subtypeFilter) {
+      const nestedNamespaces = (
+        result.results.length === 1
+          ? (result.results[0] as { data?: { namespaces?: Array<{ subtypes?: string[] }> } }).data?.namespaces
+          : null
+      );
+      if (Array.isArray(nestedNamespaces)) {
+        const before = nestedNamespaces.length;
+        const filtered = nestedNamespaces.filter(
+          (n) => Array.isArray(n.subtypes) && n.subtypes.includes(subtypeFilter)
+        );
+        const single = result.results[0] as { data: Record<string, unknown> };
+        return c.json({
+          ...result,
+          results: [{ ...single, data: { ...single.data, namespaces: filtered, namespace_count: filtered.length } }],
+          filter: { subtype: subtypeFilter, total_before_filter: before },
+          ...(filtered.length === 0 && before > 0
+            ? { message: `No namespaces with subtype "${subtypeFilter}" found in this type.` }
+            : {}),
+        });
+      }
+      // Fallback: top-level filtering (per-entry results with data.subtypes).
+      const before = result.results.length;
+      const filtered = result.results.filter((r) => {
+        const data = (r as { data?: { subtypes?: unknown } }).data;
+        const subtypes = data?.subtypes;
+        return Array.isArray(subtypes) && subtypes.includes(subtypeFilter);
+      });
+      return c.json({
+        ...result,
+        results: filtered,
+        filter: { subtype: subtypeFilter, total_before_filter: before },
+        ...(filtered.length === 0 && before > 0
+          ? { message: `No namespaces with subtype "${subtypeFilter}" found in this type.` }
+          : {}),
+      });
+    }
     return c.json(result);
   } catch (err) {
     const entry = buildErrorEntry("api.resolve", decoded, err, c.req.raw);

--- a/src/kv-resolve.ts
+++ b/src/kv-resolve.ts
@@ -62,12 +62,19 @@ export async function resolveFromKV(
   // 1. Extract type without KV
   const type = extractSecIDType(input);
   if (!type) {
-    // No valid type prefix — try bare identifier search across all types.
-    // e.g., "CVE-2024-1234" → search all types' child_index for matches.
-    const bareResult = await searchBareIdentifier(ctx, input);
-    if (bareResult) return bareResult;
+    // No valid type. Two sub-cases:
+    //   (a) Input has no "secid:" prefix → treat as bare identifier; search
+    //       all types' indices for matches (e.g., "CVE-2024-1234", "cwe").
+    //   (b) Input HAS "secid:" prefix but the type is unknown → user explicitly
+    //       typed an invalid SecID; don't fish for matches. Fall through to
+    //       the resolver's invalid-type error path.
+    const hasSecidPrefix = /^secid:/i.test(input.trimStart());
+    if (!hasSecidPrefix) {
+      const bareResult = await searchBareIdentifier(ctx, input);
+      if (bareResult) return bareResult;
+    }
 
-    // Nothing matched — let the resolver produce the error message.
+    // Nothing matched (or invalid explicit SecID) — let the resolver produce the error message.
     const parsed = parseSecID(input, {});
     return resolve(parsed, {});
   }
@@ -237,12 +244,16 @@ async function searchBareIdentifier(
   const trimmed = input.trim();
   if (!trimmed) return null;
 
-  // Single KV read: combined child_index across all types
+  // Single KV read: combined index across all types
   const globalIndex = await ctx.getGlobalIndex();
   if (!globalIndex?.child_index) return null;
 
-  // Pattern-match against the global child_index
-  const matchesByType = new Map<SecIDType, Set<string>>();
+  // Pattern-match against the global index. Source-level and child-level
+  // matches go through different resolution paths — a "cwe" match is a
+  // source identity (resolve weakness/mitre.org/cwe), whereas a "CVE-2021-44228"
+  // match is a cross-source item lookup.
+  const sourceMatches: Array<{ type: SecIDType; namespace: string; nameSlug: string }> = [];
+  const childMatchesByType = new Map<SecIDType, Set<string>>();
   for (const entry of globalIndex.child_index) {
     for (const pat of entry.patterns) {
       try {
@@ -250,10 +261,19 @@ async function searchBareIdentifier(
           ? new RegExp(pat.slice(4), "i")
           : new RegExp(pat);
         if (re.test(trimmed)) {
-          if (!matchesByType.has(entry.type)) {
-            matchesByType.set(entry.type, new Set());
+          // entry.level may be absent on older deploys — treat as "child" for compat
+          if (entry.level === "source") {
+            sourceMatches.push({
+              type: entry.type,
+              namespace: entry.namespace,
+              nameSlug: entry.name_slug,
+            });
+          } else {
+            if (!childMatchesByType.has(entry.type)) {
+              childMatchesByType.set(entry.type, new Set());
+            }
+            childMatchesByType.get(entry.type)!.add(entry.namespace);
           }
-          matchesByType.get(entry.type)!.add(entry.namespace);
           break;
         }
       } catch {
@@ -262,28 +282,49 @@ async function searchBareIdentifier(
     }
   }
 
-  if (matchesByType.size === 0) return null;
+  if (sourceMatches.length === 0 && childMatchesByType.size === 0) return null;
 
-  // Resolve across all matching types in parallel.
-  // Construct ParsedSecID directly (bypasses parser's dot-means-domain heuristic).
-  const resolveResults = await Promise.all(
-    [...matchesByType.entries()].map(async ([type, namespaces]) => {
-      const parsed: ParsedSecID = {
-        raw: input,
-        prefix: false,
-        type,
-        namespace: null,
-        name: trimmed,
-        version: null,
-        subpath: null,
-        itemVersion: null,
-        qualifiers: null,
-      };
-      const nsMap = await ctx.getNamespaces(type, [...namespaces]);
-      const registry = buildPartialRegistry(type, nsMap);
-      return resolve(parsed, registry);
-    })
-  );
+  // Resolve source-level matches: each becomes a fully-qualified query
+  // (namespace + name set) so the resolver returns the source itself.
+  const sourceResolvePromises = sourceMatches.map(async ({ type, namespace, nameSlug }) => {
+    const parsed: ParsedSecID = {
+      raw: input,
+      prefix: false,
+      type,
+      namespace,
+      name: nameSlug,
+      version: null,
+      subpath: null,
+      itemVersion: null,
+      qualifiers: null,
+    };
+    const nsMap = await ctx.getNamespaces(type, [namespace]);
+    const registry = buildPartialRegistry(type, nsMap);
+    return resolve(parsed, registry);
+  });
+
+  // Resolve child-level matches: existing type-scoped cross-source search.
+  const childResolvePromises = [...childMatchesByType.entries()].map(async ([type, namespaces]) => {
+    const parsed: ParsedSecID = {
+      raw: input,
+      prefix: false,
+      type,
+      namespace: null,
+      name: trimmed,
+      version: null,
+      subpath: null,
+      itemVersion: null,
+      qualifiers: null,
+    };
+    const nsMap = await ctx.getNamespaces(type, [...namespaces]);
+    const registry = buildPartialRegistry(type, nsMap);
+    return resolve(parsed, registry);
+  });
+
+  const resolveResults = await Promise.all([
+    ...sourceResolvePromises,
+    ...childResolvePromises,
+  ]);
 
   // Aggregate results from all types
   const allResults: ResultEntry[] = [];

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -77,16 +77,34 @@ function listNamespaces(
   type: string,
   typeRegistry: Record<string, RegistryNamespace>
 ): ResolveResponse {
+  // Note: in the live worker, type-only queries (e.g., "secid:methodology")
+  // short-circuit in kv-resolve.ts and return data straight from the
+  // TypeIndex KV key without ever reaching this function. The path here
+  // remains for in-memory resolution against a fully-loaded Registry —
+  // tests, future client SDKs, and partial-registry resolution after
+  // bare-name search.
   const results: RegistryResult[] = Object.entries(typeRegistry)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([ns, data]) => ({
-      secid: `secid:${type}/${ns}`,
-      data: {
-        official_name: data.official_name,
-        common_name: data.common_name,
-        source_count: data.match_nodes.length,
-      },
-    }));
+    .map(([ns, data]) => {
+      const subtypes = new Set<string>();
+      for (const node of data.match_nodes ?? []) {
+        const raw = (node.data as Record<string, unknown> | undefined)?.subtype;
+        if (Array.isArray(raw)) {
+          for (const v of raw) if (typeof v === "string") subtypes.add(v);
+        } else if (typeof raw === "string") {
+          subtypes.add(raw);
+        }
+      }
+      return {
+        secid: `secid:${type}/${ns}`,
+        data: {
+          official_name: data.official_name,
+          common_name: data.common_name,
+          source_count: data.match_nodes.length,
+          subtypes: [...subtypes].sort(),
+        },
+      };
+    });
 
   return response(query, "found", results);
 }
@@ -610,8 +628,37 @@ function typeScopedSearch(
 
   for (const [nsKey, ns] of Object.entries(typeRegistry)) {
     for (const node of ns.match_nodes) {
-      if (!node.children) continue;
+      // Source-level pattern match — user typed the source's own name
+      // (e.g., "cwe" matches the cwe source in weakness/mitre.org).
+      // Return source-level info rather than a child resolution.
+      if (matchesAnyPattern(node.patterns, identifier)) {
+        const nameSlug = extractNameSlug(node);
+        const secid = `secid:${parsed.type}/${nsKey}/${nameSlug}`;
+        // Prefer source-level url; fall back to first namespace url; otherwise
+        // emit a RegistryResult with description so the consumer at least gets
+        // useful metadata.
+        const sourceUrl = node.data?.url ?? ns.urls?.[0]?.url;
+        if (sourceUrl) {
+          const res: ResolutionResult = { secid, weight: node.weight ?? 100, url: sourceUrl };
+          addFormatMetadata(res, node.data ?? {});
+          results.push(res);
+        } else {
+          results.push({
+            secid,
+            data: {
+              description: node.description,
+              weight: node.weight ?? 100,
+              official_name: ns.official_name,
+              common_name: ns.common_name,
+              child_count: node.children?.length ?? 0,
+            },
+          } as RegistryResult);
+        }
+      }
 
+      // Child-level pattern match — user typed an item identifier
+      // (e.g., "CVE-2021-44228" matches a child of the cve source).
+      if (!node.children) continue;
       for (const child of node.children) {
         if (!matchesAnyPattern(child.patterns, identifier)) continue;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,6 +147,11 @@ export interface TypeIndex {
     official_name: string;
     common_name: string | null;
     source_count: number;
+    /** Union of subtype values across all source-level match_nodes in this
+     *  namespace (e.g., ["mapping", "scoring"]). Empty array means no
+     *  subtype tags. Older deploys may omit this field; treat absent as
+     *  empty for filter purposes. */
+    subtypes?: string[];
   }>;
   child_index: ChildIndexEntry[];
 }
@@ -154,6 +159,14 @@ export interface TypeIndex {
 export interface ChildIndexEntry {
   namespace: string;
   name_slug: string;
+  /**
+   * "source" entries match the source-level match_node itself (e.g., "cwe"
+   * matches weakness/mitre.org/cwe). "child" entries match a specific item
+   * identifier within a source (e.g., "CVE-2021-44228" matches a child of
+   * advisory/mitre.org/cve). Older deploys may omit this field; treat
+   * absent as "child" for backward compatibility.
+   */
+  level?: "source" | "child";
   patterns: string[];
   description: string;
   weight: number;

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -107,6 +107,55 @@ describe("REST API", () => {
       };
       expect(body.status).toBe("found");
     });
+
+    it("?subtype= filters the namespace listing for a bare-type query", async () => {
+      // First request — no filter, get the full set. Type-only queries return
+      // a single wrapper result with data.namespaces[] nested inside.
+      const full = await SELF.fetch(
+        "https://test.local/api/v1/resolve?secid=secid:methodology"
+      );
+      const fullBody = (await full.json()) as {
+        results: Array<{ data: { namespaces?: Array<{ namespace: string; subtypes?: string[] }> } }>;
+      };
+      const fullNamespaces = fullBody.results[0]?.data?.namespaces;
+      expect(Array.isArray(fullNamespaces)).toBe(true);
+      expect(fullNamespaces!.length).toBeGreaterThan(0);
+      // Every namespace entry should carry a subtypes array
+      expect(fullNamespaces![0].subtypes).toBeDefined();
+
+      // Now apply ?subtype=scoring and confirm filtering happens
+      const filtered = await SELF.fetch(
+        "https://test.local/api/v1/resolve?secid=secid:methodology&subtype=scoring"
+      );
+      const filteredBody = (await filtered.json()) as {
+        results: Array<{ data: { namespaces?: Array<{ namespace: string; subtypes?: string[] }> } }>;
+        filter?: { subtype?: string; total_before_filter?: number };
+      };
+      // Filter metadata returned
+      expect(filteredBody.filter?.subtype).toBe("scoring");
+      expect(filteredBody.filter?.total_before_filter).toBe(fullNamespaces!.length);
+      const filteredNamespaces = filteredBody.results[0]?.data?.namespaces;
+      expect(filteredNamespaces!.length).toBeGreaterThan(0);
+      expect(filteredNamespaces!.length).toBeLessThan(fullNamespaces!.length);
+      // Every remaining namespace must include "scoring" in its subtypes
+      for (const n of filteredNamespaces!) {
+        expect(n.subtypes).toContain("scoring");
+      }
+    });
+
+    it("?subtype=nonexistent returns empty results with a helpful message", async () => {
+      const res = await SELF.fetch(
+        "https://test.local/api/v1/resolve?secid=secid:methodology&subtype=does-not-exist-xyzzy"
+      );
+      const body = (await res.json()) as {
+        results: Array<{ data: { namespaces?: unknown[] } }>;
+        filter?: { subtype?: string };
+        message?: string;
+      };
+      expect(body.results[0]?.data?.namespaces?.length).toBe(0);
+      expect(body.filter?.subtype).toBe("does-not-exist-xyzzy");
+      expect(body.message).toContain("does-not-exist-xyzzy");
+    });
   });
 
   describe("lang qualifier", () => {

--- a/test/helpers/seed-kv.ts
+++ b/test/helpers/seed-kv.ts
@@ -42,6 +42,10 @@ function extractNameSlug(node: MatchNodeLike): string {
 
 export async function seedRegistryKV(kv: KVNamespace): Promise<void> {
   const typeCounts: Record<string, number> = {};
+  // Combined index across all types — must mirror the production upload script
+  // (scripts/upload-registry-kv.ts) so tests exercise the same bare-name and
+  // cross-source search paths the live deploy hits.
+  const globalChildIndex: Array<ChildIndexEntry & { type: string; level: "source" | "child" }> = [];
   let total = 0;
 
   for (const [type, namespaces] of Object.entries(REGISTRY)) {
@@ -64,7 +68,8 @@ export async function seedRegistryKV(kv: KVNamespace): Promise<void> {
         common_name: string | null;
         match_nodes: MatchNodeLike[];
       };
-      // Build child_index entries
+      // Build child_index entries (per-type — child level only; matches the
+      // production TypeIndex shape).
       for (const node of nsData.match_nodes ?? []) {
         const nameSlug = extractNameSlug(node);
         for (const child of node.children ?? []) {
@@ -78,11 +83,51 @@ export async function seedRegistryKV(kv: KVNamespace): Promise<void> {
           });
         }
       }
+      // Build global index entries (both source-level and child-level —
+      // matches the production secid:* key shape).
+      for (const node of nsData.match_nodes ?? []) {
+        const nameSlug = extractNameSlug(node);
+        globalChildIndex.push({
+          type,
+          namespace: ns,
+          name_slug: nameSlug,
+          level: "source",
+          patterns: node.patterns,
+          description: node.description,
+          weight: node.weight ?? 100,
+          has_url: !!(node.data?.url),
+        });
+        for (const child of node.children ?? []) {
+          globalChildIndex.push({
+            type,
+            namespace: ns,
+            name_slug: nameSlug,
+            level: "child",
+            patterns: child.patterns,
+            description: child.description,
+            weight: child.weight,
+            has_url: !!child.data?.url,
+          });
+        }
+      }
+      // Union of subtype values across all source-level match_nodes — mirrors
+      // the production upload script so filter tests can exercise the same
+      // shape the live deploy returns.
+      const subtypes = new Set<string>();
+      for (const node of nsData.match_nodes ?? []) {
+        const raw = (node.data as Record<string, unknown> | undefined)?.subtype;
+        if (Array.isArray(raw)) {
+          for (const v of raw) if (typeof v === "string") subtypes.add(v);
+        } else if (typeof raw === "string") {
+          subtypes.add(raw);
+        }
+      }
       return {
         namespace: ns,
         official_name: nsData.official_name,
         common_name: nsData.common_name,
         source_count: nsData.match_nodes?.length ?? 0,
+        subtypes: [...subtypes].sort(),
       };
     });
 
@@ -95,6 +140,9 @@ export async function seedRegistryKV(kv: KVNamespace): Promise<void> {
     };
     await kv.put(`secid:${type}`, JSON.stringify(typeIndex));
   }
+
+  // Write secid:* (global index for bare-name lookup)
+  await kv.put("secid:*", JSON.stringify({ child_index: globalChildIndex }));
 
   // Write secid:registry
   await kv.put("secid:registry", JSON.stringify(REGISTRY));

--- a/test/kv-resolve.test.ts
+++ b/test/kv-resolve.test.ts
@@ -135,6 +135,23 @@ describe("resolveFromKV", () => {
     expect(secids.some((s) => s.includes("mitre.org"))).toBe(true);
   });
 
+  it("finds source-level match for bare name (cwe)", async () => {
+    // Regression test for TODO entry "cross-source search misses bare MITRE
+    // acronyms" — searching for "cwe" with no type prefix should surface
+    // weakness/mitre.org/cwe via the global index's source-level entries.
+    const result = await resolveFromKV(env.secid_REGISTRY, "cwe");
+    expect(result.status).toBe("found");
+    const secids = result.results.map((r) => (r as { secid: string }).secid);
+    expect(secids.some((s) => s === "secid:weakness/mitre.org/cwe")).toBe(true);
+  });
+
+  it("finds source-level match for bare name (capec)", async () => {
+    const result = await resolveFromKV(env.secid_REGISTRY, "capec");
+    expect(result.status).toBe("found");
+    const secids = result.results.map((r) => (r as { secid: string }).secid);
+    expect(secids.some((s) => s === "secid:ttp/mitre.org/capec")).toBe(true);
+  });
+
   it("handles invalid type", async () => {
     const result = await resolveFromKV(
       env.secid_REGISTRY,

--- a/website/src/components/Resolver.astro
+++ b/website/src/components/Resolver.astro
@@ -360,9 +360,10 @@
     output.hidden = false;
     output.textContent = "Resolving\u2026";
     try {
-      const data = await fetchResolve(secid);
+      const subtype = currentSubtypeFilter();
+      const data = await fetchResolve(secid, { subtype });
       renderResponse(output, data);
-      document.title = `${secid} \u2014 SecID`;
+      document.title = `${secid}${subtype ? ` [subtype=${subtype}]` : ""} \u2014 SecID`;
     } catch (err) {
       output.textContent = `Error: ${(err as Error).message}`;
     }
@@ -429,10 +430,18 @@
   });
 
   // --- API helper ---
-  async function fetchResolve(secid: string): Promise<ResolveResponse> {
-    const url = `/api/v1/resolve?secid=${encodeURIComponent(secid)}`;
+  async function fetchResolve(secid: string, opts?: { subtype?: string | null }): Promise<ResolveResponse> {
+    let url = `/api/v1/resolve?secid=${encodeURIComponent(secid)}`;
+    if (opts?.subtype) {
+      url += `&subtype=${encodeURIComponent(opts.subtype)}`;
+    }
     const res = await fetch(url);
     return res.json();
+  }
+
+  /** Read ?subtype= from the current URL once, returned as a string or null. */
+  function currentSubtypeFilter(): string | null {
+    return new URLSearchParams(window.location.search).get("subtype");
   }
 
   // --- Close button helper ---
@@ -526,6 +535,48 @@
     header.appendChild(querySpan);
 
     container.appendChild(header);
+
+    // Active subtype filter indicator (sent back by the API when ?subtype= is applied).
+    // Build via explicit DOM nodes to keep the filter.subtype value (read from the URL)
+    // from ever being interpreted as HTML.
+    const filter = (data as unknown as { filter?: { subtype?: string; total_before_filter?: number } }).filter;
+    if (filter?.subtype) {
+      const filterBar = document.createElement("div");
+      filterBar.style.marginTop = "0.4rem";
+      filterBar.style.padding = "0.3rem 0.5rem";
+      filterBar.style.background = "var(--bg-elevated, #eee)";
+      filterBar.style.borderRadius = "4px";
+      filterBar.style.fontSize = "0.8rem";
+      filterBar.style.display = "flex";
+      filterBar.style.alignItems = "center";
+      filterBar.style.gap = "0.5rem";
+
+      const labelPrefix = document.createElement("span");
+      labelPrefix.textContent = "Filtered by subtype:";
+      filterBar.appendChild(labelPrefix);
+
+      const labelCode = document.createElement("code");
+      labelCode.textContent = filter.subtype;
+      filterBar.appendChild(labelCode);
+
+      const before = filter.total_before_filter ?? 0;
+      const after = data.results.length;
+      const counts = document.createElement("span");
+      counts.style.color = "var(--fg-muted)";
+      counts.textContent = `(${after} of ${before})`;
+      filterBar.appendChild(counts);
+
+      const clearBtn = document.createElement("a");
+      clearBtn.textContent = "clear filter";
+      const params = new URLSearchParams(window.location.search);
+      params.delete("subtype");
+      clearBtn.href = `${window.location.pathname}?${params.toString()}`;
+      clearBtn.style.marginLeft = "auto";
+      clearBtn.style.fontSize = "0.75rem";
+      filterBar.appendChild(clearBtn);
+
+      container.appendChild(filterBar);
+    }
 
     // Message if present
     if (data.message) {

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -108,7 +108,13 @@ secid:control/nist.gov/800-53@r5#AC-1
             <div class="type-subtypes">
               <span class="subtypes-label">Subtypes:</span>
               {t.subtypes.map((s) => (
-                <code class="subtype-chip">{s.value}</code>
+                <a
+                  href={`/resolve?secid=secid:${t.type}&subtype=${s.value}`}
+                  class="subtype-chip-link"
+                  title={s.description}
+                >
+                  <code class="subtype-chip">{s.value}</code>
+                </a>
               ))}
             </div>
           )}
@@ -264,6 +270,14 @@ secid:control/nist.gov/800-53@r5#AC-1
     background: var(--bg-elevated, #eee);
     font-size: 0.7rem;
     word-break: keep-all;
+  }
+  .type-subtypes .subtype-chip-link {
+    text-decoration: none;
+    color: inherit;
+  }
+  .type-subtypes .subtype-chip-link:hover .subtype-chip {
+    background: var(--accent-bg, #d0d4dc);
+    text-decoration: underline;
   }
   .type-card h3 a {
     color: inherit;


### PR DESCRIPTION
Three related items shipped together because they share TypeIndex / global-index schema changes.

## 1. Bare-name cross-source search now finds source-level matches

**Bug:** \`?secid=cwe\` returned not_found even though \`secid:weakness/mitre.org/cwe\` was in the registry. The \`secid:*\` global index only had child-level patterns (e.g., \`^CWE-\\d+$\`); source-level patterns like \`(?i)^cwe$\` were never indexed. Same problem affected \`capec\` and other MITRE short names. Tracked in SecID/docs/project/TODO.md (PR #48).

**Fix:**
- \`ChildIndexEntry\` gains a \`level: \"source\" | \"child\"\` discriminator
- Upload script + test seed helper now emit both source-level AND child-level entries
- \`searchBareIdentifier\` routes source-level matches to a fully-qualified parsed result (so the resolver returns source info, not a child resolution)
- \`typeScopedSearch\` also walks source-level patterns

**Bonus fix discovered while testing:** the \`returns not_found for invalid type\` test was inadvertently passing because seed-kv.ts wasn't populating the global index. Once that was fixed, control/ibm.com's \`^.+$\` child pattern matched everything, including \`secid:frobnicate/mitre.org\`. Now: when input has an explicit \`secid:\` prefix but invalid type, don't fish for bare-search matches; report invalid type.

**Tests:** added regression tests for \`cwe\` and \`capec\`.

## 2. Subtype filter UI

**What:** Subtype chips on the homepage are now clickable links to \`/resolve?secid=secid:<type>&subtype=<value>\`. The API accepts the new \`?subtype=\` query param and filters namespace listings to those whose match_nodes carry the requested subtype.

**Implementation:**
- \`TypeIndex.namespaces\` gains optional \`subtypes: string[]\` (union of subtype values across each namespace's match_nodes)
- Upload script + seed helper populate it during the same walk as child_index (no extra traversal)
- \`handleResolve\` post-processes the resolve result, filtering either the nested \`data.namespaces\` array (type-only query short-circuit shape) or top-level results, depending on shape. Returns a \`filter: {subtype, total_before_filter}\` envelope and a helpful message when nothing matches.
- \`Resolver.astro\` reads \`?subtype=\` from the URL, passes it through, renders a \"Filtered by subtype: X (clear filter)\" bar. URL-derived value never touches \`innerHTML\`.
- \`index.astro\` wraps subtype chips in anchor tags with hover styling.

## 3. Auto-deploy on push to main

**Why:** Per session notes, this repo had no auto-deploy on push-to-main; every PR merge required a manual \`gh workflow run \"Upload registry to KV\"\` to ship. The existing workflow already does all the right steps; just needed a push trigger.

**Change:** Added \`push: branches: [main]\` to \`registry-kv-upload.yml\`. Workflow docstring updated to note the three triggers and to flag that no untrusted GitHub event data is interpolated into shell commands.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx tsc --noEmit\` clean for src/
- [x] All 287 tests pass (up from 230; +57 from refreshed REGISTRY having more namespaces plus new bare-name + filter tests)
- [ ] After merge + deploy: \`curl https://secid.cloudsecurityalliance.org/api/v1/resolve?secid=cwe\` returns \`secid:weakness/mitre.org/cwe\` in results
- [ ] After merge + deploy: \`curl 'https://secid.cloudsecurityalliance.org/api/v1/resolve?secid=secid:methodology&subtype=scoring'\` returns only methodology namespaces with \`scoring\` in their subtypes
- [ ] After merge + deploy: visit homepage, click a chip → page navigates to filtered explorer view with \"Filtered by subtype: X\" bar
- [ ] Future merges into this repo trigger an automatic deploy (no \`gh workflow run\` needed)

## Coordination note

Per the user's flag that \"other AI tools are working in here as well\": this PR touches infrastructure files (workflow, KV schema via the new \`level\` and \`subtypes\` fields). The changes are additive — older clients that don't know about \`level\` or \`subtypes\` continue to work (level defaults to \"child\" for compat; absent subtypes treated as empty for filter purposes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)