### PR TITLE
type-registry: add incident subtype to advisory

### DIFF
--- a/src/type-registry.ts
+++ b/src/type-registry.ts
@@ -42,7 +42,9 @@ export const TYPE_REGISTRY: readonly TypeDef[] = [
     type: "advisory",
     short: "Vulnerability publications — CVEs, vendor advisories, GHSAs, incident reports",
     long: "Publications about vulnerabilities — CVE records, GHSA advisories, vendor advisories, and incident reports (AIID, NHTSA, FDA adverse events). Both vuln advisories and incident reports answer 'this happened.'",
-    subtypes: [],
+    subtypes: [
+      { value: "incident", description: "Incident reports — publications documenting that an AI, automated, or computing system caused harm or behaved badly. Sources include AIID, AIAAIC, NHTSA SGO crash reports, and CA DMV autonomous-vehicle reports." },
+    ],
   },
   {
     type: "capability",


### PR DESCRIPTION
## Summary
Declares \`incident\` as a named subtype of \`advisory\` in the canonical type registry. This formalizes a pattern already documented in SecID's \`docs/reference/TYPES-AND-SUBTYPES.md\` "Implicit overloads" table as the anticipated value for AIID, NHTSA SGO, FDA adverse events, etc.

## Why this PR exists separately
\`scripts/validate-subtypes.py\` in the SecID repo fetches \`type-registry.ts\` from this repo's \`main\` to enforce that every \`subtype:\` value in registry data is declared here. Merging this PR first is what unblocks the follow-up SecID PR that:
1. Updates \`docs/reference/TYPES-AND-SUBTYPES.md\` to document \`incident\` under the "Named subtypes in use today" section
2. Tags four matching registry entries: \`advisory/gov/nhtsa\` (SGO match_node), \`advisory/org/aiaaic\`, \`advisory/gov/ca/dmv\`, \`advisory/org/partnershiponai\` (AIID)

## Test plan
- [x] \`npx vitest run\` — 287/287 tests pass locally
- [x] Subtype-consuming code (\`resolver.ts\`, \`api.ts\`) is shape-agnostic — uses \`.map()\` and \`.includes()\`, never assumes empty array
- [ ] After merge: \`registry-kv-upload.yml\` workflow auto-runs tests + deploys; verify via \`curl https://secid.cloudsecurityalliance.org/api/v1/types | jq '.types[] | select(.type=="advisory") | .subtypes'\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)