### PR TITLE
seed-kv: import TYPE_SHORT_DESCRIPTIONS instead of hardcoding

### DIFF
--- a/test/helpers/seed-kv.ts
+++ b/test/helpers/seed-kv.ts
@@ -7,18 +7,7 @@
 
 import { REGISTRY } from "../../src/registry";
 import type { ChildIndexEntry, TypeIndex } from "../../src/types";
-
-const TYPE_DESCRIPTIONS: Record<string, string> = {
-  advisory:
-    "Publications about vulnerabilities (CVE, GHSA, vendor advisories, incident reports)",
-  weakness: "Abstract flaw patterns (CWE, OWASP Top 10)",
-  ttp: "Adversary techniques (ATT&CK, ATLAS, CAPEC)",
-  control: "Security requirements (NIST CSF, ISO 27001, benchmarks)",
-  regulation: "Laws and legal requirements (GDPR, HIPAA)",
-  entity: "Organizations, products, services",
-  reference:
-    "Documents, research, identifier systems (arXiv, DOI, ISBN, RFCs)",
-};
+import { TYPE_SHORT_DESCRIPTIONS } from "../../src/type-registry";
 
 interface MatchNodeLike {
   patterns: string[];
@@ -133,7 +122,7 @@ export async function seedRegistryKV(kv: KVNamespace): Promise<void> {
 
     const typeIndex: TypeIndex = {
       type,
-      description: TYPE_DESCRIPTIONS[type] ?? type,
+      description: TYPE_SHORT_DESCRIPTIONS[type] ?? type,
       namespace_count: nsList.length,
       namespaces: nsList,
       child_index: childIndex,


### PR DESCRIPTION
## Summary
Eliminates a small drift risk in \`test/helpers/seed-kv.ts\`. The file had its own hardcoded \`TYPE_DESCRIPTIONS\` map duplicating content already in \`type-registry.ts\`. Now imports \`TYPE_SHORT_DESCRIPTIONS\` from the canonical source.

## Context
Found during a broader testing/infrastructure audit. \`type-registry.ts\`'s own header comment claims "SINGLE SOURCE OF TRUTH for SecID types and their named subtypes" — this fix closes one of the last gaps where that claim wasn't quite true.

## Test plan
- [x] \`npx vitest run\` — 287/287 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)