### PR TITLE
Add submission_url to not_found + capture misses in secid_FEEDBACK

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -122,7 +122,10 @@ export async function handleResolve(c: Context<AppEnv>): Promise<Response> {
         message: "Registry KV not configured.",
       });
     }
-    const result = await resolveFromKV(kv, decoded);
+    const result = await resolveFromKV(kv, decoded, {
+      feedbackKv: c.env.secid_FEEDBACK,
+      waitUntil: (p) => c.executionCtx.waitUntil(p),
+    });
 
     // Optional ?subtype= filter — applies to namespace listings within a type.
     // Two response shapes need handling:

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,0 +1,74 @@
+// ── Feedback: missed-namespace capture ──
+// When a well-formed query names a type+namespace that isn't in the registry,
+// we record it here so we have a ranked backlog of the most-requested sources
+// we don't yet cover — demand signal even from callers who never submit.
+//
+// Aggregated by key (miss:<type>/<namespace>), NOT one row per request, so the
+// number of KV writes is bounded by *distinct* missed namespaces rather than
+// request volume — a bot hammering random namespaces can't blow the KV quota,
+// and the stored shape is already the thing we want ("namespace X, requested N
+// times") rather than a pile of events to tally later.
+//
+// Stored in the secid_FEEDBACK KV namespace. Inspect with:
+//   wrangler kv key list --binding secid_FEEDBACK --prefix miss:
+//   wrangler kv key get  --binding secid_FEEDBACK "miss:entity/example.com"
+
+export interface MissRecord {
+  type: string;
+  namespace: string;
+  count: number;
+  first_seen: string;
+  last_seen: string;
+  sample_query: string;
+}
+
+/**
+ * Record a namespace-level miss, aggregating by (type, namespace).
+ *
+ * Read-modify-write: KV is eventually consistent, so under high concurrency
+ * the count may slightly undercount — acceptable for a demand signal. Best
+ * called via ctx.waitUntil() so it never blocks the response.
+ */
+export async function recordMiss(
+  kv: KVNamespace | undefined,
+  type: string,
+  namespace: string,
+  query: string
+): Promise<void> {
+  const key = `miss:${type}/${namespace}`;
+  const now = new Date().toISOString();
+
+  if (!kv) {
+    console.log("[secid-feedback] miss (no KV):", key);
+    return;
+  }
+
+  try {
+    const existingRaw = await kv.get(key);
+    let record: MissRecord;
+    if (existingRaw) {
+      const prev = JSON.parse(existingRaw) as MissRecord;
+      record = {
+        type,
+        namespace,
+        count: (prev.count ?? 0) + 1,
+        first_seen: prev.first_seen ?? now,
+        last_seen: now,
+        sample_query: query,
+      };
+    } else {
+      record = {
+        type,
+        namespace,
+        count: 1,
+        first_seen: now,
+        last_seen: now,
+        sample_query: query,
+      };
+    }
+    await kv.put(key, JSON.stringify(record));
+  } catch (err) {
+    // Never let feedback capture affect the response path.
+    console.error("[secid-feedback] KV write failed:", err);
+  }
+}

--- a/src/kv-resolve.ts
+++ b/src/kv-resolve.ts
@@ -1,6 +1,7 @@
 import { RegistryContext } from "./kv-registry";
 import { extractSecIDType, parseSecID } from "./parser";
 import { resolve } from "./resolver";
+import { recordMiss } from "./feedback";
 import {
   isResolutionResult,
   SECID_TYPES,
@@ -26,9 +27,21 @@ import {
  * 5. Fetch the namespace(s) needed for resolution
  * 6. Build a real (but partial) Registry and resolve
  */
+/**
+ * Optional hook for capturing namespace-level misses. When provided, a
+ * `not_found` carrying a `submission_url` (i.e. a recognized type + a
+ * namespace that isn't registered) is recorded to the feedback KV. Passing
+ * `waitUntil` keeps the KV write off the response path.
+ */
+export interface MissCapture {
+  feedbackKv?: KVNamespace;
+  waitUntil?: (p: Promise<unknown>) => void;
+}
+
 export async function resolveFromKV(
   kv: KVNamespace,
-  input: string
+  input: string,
+  capture?: MissCapture
 ): Promise<ResolveResponse> {
   const ctx = new RegistryContext(kv);
 
@@ -122,7 +135,24 @@ export async function resolveFromKV(
 
   // 7. Build real (partial) registry and resolve
   const registry = buildPartialRegistry(type, nsMap);
-  return resolve(parsed, registry);
+  const result = resolve(parsed, registry);
+
+  // Capture namespace-level misses. The resolver only sets submission_url when
+  // a recognized type names a namespace that isn't registered — exactly the
+  // actionable "we should add this" signal.
+  if (
+    capture?.feedbackKv &&
+    result.status === "not_found" &&
+    result.submission_url &&
+    parsed.type &&
+    parsed.namespace
+  ) {
+    const write = recordMiss(capture.feedbackKv, parsed.type, parsed.namespace, input);
+    if (capture.waitUntil) capture.waitUntil(write);
+    else await write;
+  }
+
+  return result;
 }
 
 /**

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { z } from "zod";
-import { resolveFromKV } from "./kv-resolve";
+import { resolveFromKV, type MissCapture } from "./kv-resolve";
 import { RegistryContext } from "./kv-registry";
 import { SECID_TYPES } from "./types";
 import type { AppEnv } from "./types";
@@ -380,7 +380,8 @@ Use this to help users construct valid SecID strings or to explore what the regi
 function createMcpServer(
   kv: KVNamespace | undefined,
   registryKv: KVNamespace,
-  req: Request
+  req: Request,
+  capture?: MissCapture
 ): McpServer {
   const server = new McpServer({
     name: "secid",
@@ -412,7 +413,7 @@ function createMcpServer(
         };
       }
       try {
-        const result = await resolveFromKV(registryKv, secid);
+        const result = await resolveFromKV(registryKv, secid, capture);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
@@ -463,7 +464,7 @@ function createMcpServer(
       }
       const secid = `secid:${type}/${identifier}`;
       try {
-        const result = await resolveFromKV(registryKv, secid);
+        const result = await resolveFromKV(registryKv, secid, capture);
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
         };
@@ -515,7 +516,7 @@ function createMcpServer(
         // Strip subpath (#...) from input for describe — return source-level info
         const hashIdx = secid.indexOf("#");
         const describeInput = hashIdx !== -1 ? secid.slice(0, hashIdx) : secid;
-        const result = await resolveFromKV(registryKv, describeInput);
+        const result = await resolveFromKV(registryKv, describeInput, capture);
 
         // Bare-type query (secid:<type>): augment response with declared subtypes
         // from the type-registry. Lets MCP clients discover what subtypes exist
@@ -705,7 +706,10 @@ export async function handleMCP(c: Context<AppEnv>): Promise<Response> {
     );
   }
 
-  const server = createMcpServer(c.env.secid_OBSERVABILITY, c.env.secid_REGISTRY, c.req.raw);
+  const server = createMcpServer(c.env.secid_OBSERVABILITY, c.env.secid_REGISTRY, c.req.raw, {
+    feedbackKv: c.env.secid_FEEDBACK,
+    waitUntil: (p) => c.executionCtx.waitUntil(p),
+  });
 
   try {
     const transport = new WebStandardStreamableHTTPServerTransport({

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -51,13 +51,17 @@ export function resolve(
 
   const ns = typeRegistry[parsed.namespace!];
 
-  // Namespace not in registry
+  // Namespace not in registry — a namespace-level miss. Offer a prefilled
+  // submission link; callers use the presence of submission_url to record
+  // the miss (see recordMiss).
   if (!ns) {
+    const submissionUrl = buildSubmissionUrl(parsed.type, parsed.namespace!);
     return response(
       query,
       "not_found",
       [],
-      `Namespace "${parsed.namespace}" not found in type "${parsed.type}". Request it at https://github.com/CloudSecurityAlliance/SecID/issues`
+      `Namespace "${parsed.namespace}" not found in type "${parsed.type}". Submit it at ${submissionUrl}`,
+      submissionUrl
     );
   }
 
@@ -843,9 +847,28 @@ function response(
   query: string,
   status: ResolveResponse["status"],
   results: ResultEntry[],
-  message?: string
+  message?: string,
+  submissionUrl?: string
 ): ResolveResponse {
   const r: ResolveResponse = { secid_query: query, status, results };
   if (message) r.message = message;
+  if (submissionUrl) r.submission_url = submissionUrl;
   return r;
+}
+
+const ISSUE_NEW = "https://github.com/CloudSecurityAlliance/SecID/issues/new";
+
+/**
+ * Build a deep link to the prefilled GitHub issue form for submitting a
+ * missing namespace. Entities use the short entity form (domain prefilled);
+ * every other type uses the namespace form (namespace prefilled). The field
+ * IDs (`domain`, `namespace`) match `.github/ISSUE_TEMPLATE/*.yml` in the
+ * spec repo, which is what GitHub's query-string prefill keys on.
+ */
+export function buildSubmissionUrl(type: string, namespace: string): string {
+  const ns = encodeURIComponent(namespace);
+  if (type === "entity") {
+    return `${ISSUE_NEW}?template=add-entity.yml&labels=submission,entity&domain=${ns}`;
+  }
+  return `${ISSUE_NEW}?template=add-namespace.yml&labels=submission,registry&namespace=${ns}`;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -200,6 +200,7 @@ export type SubtypeCounts = Record<string, Record<string, number>>;
 export interface AppBindings {
   secid_OBSERVABILITY?: KVNamespace;
   secid_REGISTRY?: KVNamespace;
+  secid_FEEDBACK?: KVNamespace;
 }
 
 export type AppEnv = {
@@ -240,6 +241,9 @@ export interface ResolveResponse {
   status: ResponseStatus;
   results: ResultEntry[];
   message?: string;
+  // Present on namespace-level `not_found` responses: a deep link to the
+  // prefilled GitHub issue form for submitting the missing source/entity.
+  submission_url?: string;
 }
 
 // Type guard helpers

--- a/test/feedback.test.ts
+++ b/test/feedback.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { recordMiss, type MissRecord } from "../src/feedback";
+
+// Minimal in-memory KV stand-in (recordMiss only uses get/put).
+function makeKV() {
+  const store = new Map<string, string>();
+  const kv = {
+    get: async (k: string) => store.get(k) ?? null,
+    put: async (k: string, v: string) => {
+      store.set(k, v);
+    },
+  };
+  return { kv: kv as unknown as KVNamespace, store };
+}
+
+describe("recordMiss", () => {
+  it("records a first miss with count 1 under the miss:<type>/<namespace> key", async () => {
+    const { kv, store } = makeKV();
+    await recordMiss(kv, "entity", "example.com", "secid:entity/example.com");
+
+    const raw = store.get("miss:entity/example.com");
+    expect(raw).toBeDefined();
+    const rec = JSON.parse(raw!) as MissRecord;
+    expect(rec.count).toBe(1);
+    expect(rec.type).toBe("entity");
+    expect(rec.namespace).toBe("example.com");
+    expect(rec.sample_query).toBe("secid:entity/example.com");
+    expect(rec.first_seen).toBe(rec.last_seen);
+  });
+
+  it("aggregates repeated misses: count increments, first_seen preserved", async () => {
+    const { kv, store } = makeKV();
+    // Seed an older record so first_seen is distinguishable from now.
+    store.set(
+      "miss:advisory/foo.com",
+      JSON.stringify({
+        type: "advisory",
+        namespace: "foo.com",
+        count: 3,
+        first_seen: "2020-01-01T00:00:00.000Z",
+        last_seen: "2020-01-01T00:00:00.000Z",
+        sample_query: "secid:advisory/foo.com",
+      }),
+    );
+
+    await recordMiss(kv, "advisory", "foo.com", "secid:advisory/foo.com/x#Y-1");
+
+    const rec = JSON.parse(store.get("miss:advisory/foo.com")!) as MissRecord;
+    expect(rec.count).toBe(4);
+    expect(rec.first_seen).toBe("2020-01-01T00:00:00.000Z"); // preserved
+    expect(rec.last_seen).not.toBe("2020-01-01T00:00:00.000Z"); // bumped
+    expect(rec.sample_query).toBe("secid:advisory/foo.com/x#Y-1"); // latest sample
+  });
+
+  it("is a no-op (no throw) when KV is undefined", async () => {
+    await expect(
+      recordMiss(undefined, "entity", "example.com", "secid:entity/example.com"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("never throws if the KV write fails", async () => {
+    const failingKv = {
+      get: async () => null,
+      put: async () => {
+        throw new Error("kv down");
+      },
+    } as unknown as KVNamespace;
+    await expect(
+      recordMiss(failingKv, "entity", "example.com", "secid:entity/example.com"),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/test/submission-url.test.ts
+++ b/test/submission-url.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { parseSecID } from "../src/parser";
+import { resolve, buildSubmissionUrl } from "../src/resolver";
+import { REGISTRY } from "../src/registry";
+
+function resolveSecID(input: string) {
+  return resolve(parseSecID(input, REGISTRY), REGISTRY);
+}
+
+const FAKE = "definitely-not-registered-zzz.example";
+
+describe("submission_url on namespace-level miss", () => {
+  it("entity miss -> prefilled add-entity form (domain)", () => {
+    const r = resolveSecID(`secid:entity/${FAKE}`);
+    expect(r.status).toBe("not_found");
+    expect(r.submission_url).toBeDefined();
+    expect(r.submission_url).toContain("template=add-entity.yml");
+    expect(r.submission_url).toContain(`domain=${FAKE}`);
+  });
+
+  it("non-entity miss -> prefilled add-namespace form (namespace)", () => {
+    const r = resolveSecID(`secid:advisory/${FAKE}/alerts#X-1`);
+    expect(r.status).toBe("not_found");
+    expect(r.submission_url).toBeDefined();
+    expect(r.submission_url).toContain("template=add-namespace.yml");
+    expect(r.submission_url).toContain(`namespace=${FAKE}`);
+  });
+
+  it("a successful resolution carries no submission_url", () => {
+    const r = resolveSecID("secid:advisory/mitre.org/cve#CVE-2021-44228");
+    expect(r.status).toBe("found");
+    expect(r.submission_url).toBeUndefined();
+  });
+});
+
+describe("buildSubmissionUrl", () => {
+  it("percent-encodes the namespace", () => {
+    const url = buildSubmissionUrl("advisory", "ex ample.com/path");
+    expect(url).toContain("namespace=ex%20ample.com%2Fpath");
+  });
+});

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -17,5 +17,12 @@ binding = "secid_REGISTRY"
 id = "cfbc271787614516a39fa43d9ca4f95a"
 preview_id = "bda410b73cc34b468c84bf2dc9fba45f"
 
+# Captures namespace-level "not_found" misses (miss:<type>/<namespace>) so we
+# have a ranked backlog of the most-requested sources we don't yet cover.
+[[kv_namespaces]]
+binding = "secid_FEEDBACK"
+id = "61642c6485674ef597cbff50fe9b9f18"
+preview_id = "ef093fcb1caa4b55bb25f52b80082fc9"
+
 [assets]
 directory = "./website/dist"


### PR DESCRIPTION
## What

Turns every **namespace-level `not_found`** into a contribution opportunity, and captures the demand signal.

1. **`submission_url`** on the response envelope — when a recognized type names an unregistered namespace, the resolver returns a deep link to the prefilled GitHub issue form (`entity` → `add-entity.yml?domain=…`; else `add-namespace.yml?namespace=…`). Appears on both the REST API and MCP (same resolver path).
2. **Miss capture** in a new **`secid_FEEDBACK`** KV namespace — aggregated by `miss:<type>/<namespace>` into `{count, first_seen, last_seen, sample_query}`, giving a ranked backlog of the most-requested sources we don't yet cover.

## Why aggregate (not log every event)

Keying by `type/namespace` bounds KV writes to *distinct* missed namespaces, not request volume — a bot hammering random namespaces can't blow the KV quota, and the stored shape is already "namespace X, requested N times" rather than a pile of events to tally. Capture runs via `ctx.waitUntil()` (off the hot path) and never throws into the response.

## Scope of capture

Only **namespace-level misses** (recognized type + unregistered namespace) — the actionable "we should add this" signal. Malformed queries (invalid type, empty input) get a `message` but no `submission_url` and aren't recorded.

## Files

- `wrangler.toml` — `secid_FEEDBACK` binding (prod `61642c64…`, preview `ef093fcb…`, already created)
- `types.ts` — `submission_url?` on `ResolveResponse`, `secid_FEEDBACK?` on `AppBindings`
- `resolver.ts` — `buildSubmissionUrl()` + attach at the namespace-not-found site
- `feedback.ts` (new) — `recordMiss()` keyed aggregation
- `kv-resolve.ts` — optional `MissCapture`; records when `submission_url` is present
- `api.ts` + `mcp.ts` — pass capture (`feedbackKv` + `waitUntil`)
- tests — `submission-url.test.ts`, `feedback.test.ts`

## Validation

`npm test` → **295 pass** (287 existing + 8 new); `src/` typechecks clean. Spec side (envelope field + OpenAPI) documented in a companion SecID-repo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)