### PR TITLE
Fix: detect namespace-level miss in KV flow

### DIFF
--- a/src/kv-resolve.ts
+++ b/src/kv-resolve.ts
@@ -1,6 +1,6 @@
 import { RegistryContext } from "./kv-registry";
 import { extractSecIDType, parseSecID } from "./parser";
-import { resolve } from "./resolver";
+import { resolve, buildSubmissionUrl } from "./resolver";
 import { recordMiss } from "./feedback";
 import {
   isResolutionResult,
@@ -137,19 +137,27 @@ export async function resolveFromKV(
   const registry = buildPartialRegistry(type, nsMap);
   const result = resolve(parsed, registry);
 
-  // Capture namespace-level misses. The resolver only sets submission_url when
-  // a recognized type names a namespace that isn't registered — exactly the
-  // actionable "we should add this" signal.
-  if (
-    capture?.feedbackKv &&
+  // Detect a namespace-level miss authoritatively from the TypeIndex (the full
+  // namespace list), not from the resolver's message. In the KV flow only the
+  // requested namespace is fetched, so on a miss the partial registry is empty
+  // and resolve() reports "no namespaces registered for type" rather than
+  // "namespace not found" — either way, if the parsed namespace isn't in the
+  // index, it's the actionable "we should add this" signal.
+  const isNamespaceMiss =
     result.status === "not_found" &&
-    result.submission_url &&
-    parsed.type &&
-    parsed.namespace
-  ) {
-    const write = recordMiss(capture.feedbackKv, parsed.type, parsed.namespace, input);
-    if (capture.waitUntil) capture.waitUntil(write);
-    else await write;
+    !!parsed.namespace &&
+    !typeIndex.namespaces.some((n) => n.namespace === parsed.namespace);
+
+  if (isNamespaceMiss) {
+    const submissionUrl = buildSubmissionUrl(type, parsed.namespace!);
+    result.submission_url = submissionUrl;
+    result.message = `Namespace "${parsed.namespace}" not found in type "${type}". Submit it at ${submissionUrl}`;
+
+    if (capture?.feedbackKv) {
+      const write = recordMiss(capture.feedbackKv, type, parsed.namespace!, input);
+      if (capture.waitUntil) capture.waitUntil(write);
+      else await write;
+    }
   }
 
   return result;

--- a/test/kv-resolve.test.ts
+++ b/test/kv-resolve.test.ts
@@ -95,6 +95,18 @@ describe("resolveFromKV", () => {
     expect((result.results[0] as { url: string }).url).toContain("cve.org");
   });
 
+  it("namespace-level miss returns submission_url (KV flow, empty partial registry)", async () => {
+    const result = await resolveFromKV(
+      env.secid_REGISTRY,
+      "secid:advisory/definitely-not-registered-zzz.example/x#Y-1"
+    );
+    expect(result.status).toBe("not_found");
+    expect(result.submission_url).toBeDefined();
+    expect(result.submission_url).toContain("template=add-namespace.yml");
+    expect(result.submission_url).toContain("namespace=definitely-not-registered-zzz.example");
+    expect(result.message).toContain("not found");
+  });
+
   it("resolves type-only listing with metadata", async () => {
     const result = await resolveFromKV(env.secid_REGISTRY, "secid:advisory");
     expect(result.status).toBe("found");


### PR DESCRIPTION
Follow-up to #14. The submission_url logic lived at resolver.ts's namespace-not-found path, but the KV flow fetches only the requested namespace — so a miss yields an empty partial registry and resolve() takes the "no namespaces registered for type" path, never setting submission_url. Local tests missed this by using a fuller registry.

Fix: detect the miss authoritatively in `resolveFromKV` via the TypeIndex (full namespace list). Added a kv-resolve test for the real empty-partial-registry path. 296 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)