### PR TITLE
fix: validate resolved URL scheme/authority in buildUrl (F-01-01)

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -559,13 +559,56 @@ function lookupRangeTable(
 
 // ── URL Template Substitution ──
 
-function buildUrl(
+// Schemes a resolved URL may use. http: is accepted only when the template
+// itself declared it (checked below); https: is always allowed.
+const ALLOWED_URL_SCHEMES = new Set(["https:", "http:"]);
+
+/**
+ * Parse a template's literal authority by replacing every {placeholder} with an
+ * inert token, so new URL() can read its intended scheme/host. Returns null for
+ * a non-absolute template (or one whose scheme/host is itself a placeholder).
+ */
+function parseTemplateUrl(template: string): URL | null {
+  try {
+    return new URL(template.replace(/\{[^}]*\}/g, "x"));
+  } catch {
+    return null;
+  }
+}
+
+export function buildUrl(
   template: string,
   variables: Record<string, string>
-): string {
+): string | null {
+  const templateUrl = parseTemplateUrl(template);
+
   let url = template;
   for (const [key, value] of Object.entries(variables)) {
     url = url.replaceAll(`{${key}}`, value);
+  }
+
+  // Non-absolute template (no literal scheme/host to enforce): emit as-is.
+  if (!templateUrl) return url;
+
+  // Re-parse the substituted result and require that substitution did not
+  // change the scheme or authority of the template — that is the open-redirect
+  // primitive. Path/query content on the template's own host is left intact
+  // (identifiers legitimately contain ':' and other reserved chars). Fail
+  // closed on a scheme/host/userinfo change or an unparseable result.
+  let resultUrl: URL;
+  try {
+    resultUrl = new URL(url);
+  } catch {
+    return null;
+  }
+  if (resultUrl.protocol !== templateUrl.protocol) return null;
+  if (!ALLOWED_URL_SCHEMES.has(resultUrl.protocol)) return null;
+  if (
+    resultUrl.host !== templateUrl.host ||
+    resultUrl.username !== templateUrl.username ||
+    resultUrl.password !== templateUrl.password
+  ) {
+    return null;
   }
   return url;
 }

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseSecID } from "../src/parser";
-import { resolve } from "../src/resolver";
+import { resolve, buildUrl } from "../src/resolver";
 import { REGISTRY } from "../src/registry";
 import type { ResolutionResult, RegistryResult, ResolveResponse, MatchNode, ExampleObject } from "../src/types";
 
@@ -320,3 +320,32 @@ function extractTestNameSlug(node: MatchNode): string {
   }
   return node.description.toLowerCase().replace(/\s+/g, "-");
 }
+
+// ── Resolver-side URL validation (F-01-01) ──
+// buildUrl must encode user-derived values and refuse to emit a URL whose
+// scheme/authority differs from the template's literal scheme/host.
+
+describe("buildUrl URL validation (F-01-01)", () => {
+  it("substitutes a normal path-position {id}, host unchanged", () => {
+    expect(buildUrl("https://www.cve.org/CVERecord?id={id}", { id: "CVE-2021-44228" }))
+      .toBe("https://www.cve.org/CVERecord?id=CVE-2021-44228");
+  });
+
+  it("preserves reserved characters in identifiers on the template's own host", () => {
+    // RHSA IDs contain a colon — it must NOT be mangled (regression guard).
+    expect(buildUrl("https://access.redhat.com/errata/{id}", { id: "RHSA-2024:1234" }))
+      .toBe("https://access.redhat.com/errata/RHSA-2024:1234");
+    // Extra path/query content on the same host is allowed (not an open redirect).
+    expect(buildUrl("https://host.example/{id}", { id: "a/b:c?d=e" }))
+      .toBe("https://host.example/a/b:c?d=e");
+  });
+
+  it("drops a result when substitution changes the host (authority injection)", () => {
+    expect(buildUrl("https://{id}.example.com/", { id: "evil.com" })).toBeNull();
+    expect(buildUrl("https://{id}/path", { id: "evil.com" })).toBeNull();
+  });
+
+  it("passes a non-absolute template through unchanged", () => {
+    expect(buildUrl("/relative/{id}", { id: "x y" })).toBe("/relative/x y");
+  });
+});


### PR DESCRIPTION
## Finding
**F-01-01** from the 2026-06 security audit — the **resolver layer** of the "defense-in-depth URL validation" decision (client SDK + registry-CI gate are the other two layers; this is the Worker's part).

`buildUrl` substituted query-derived values (`{id}`, `{id_lower}`, `{lang}`, …) into a registry URL template via raw `replaceAll` with no validation. The registry's templates today keep placeholders in *path* position, so this is **latent** — but if a template ever placed a placeholder in the authority, a crafted identifier could steer the resolved URL's **host/scheme**, and that URL is handed to users / AI agents to navigate to (open redirect).

## Fix
`buildUrl` now re-parses the assembled URL and **fails closed** (returns `null` → the existing caller drops to a description-only result) unless the **scheme, host, and userinfo are byte-identical** to the template's literal authority (read by neutralizing `{placeholders}` → `new URL()`).

Crucially it does **not** percent-encode the substituted value — path/query content on the template's *own* host is preserved verbatim, so identifiers that legitimately contain reserved chars (e.g. `RHSA-2024:1234`) are unaffected. (An earlier draft used `encodeURIComponent` and broke the RHSA colon test; that's now a regression guard.)

## Why authority-equality, not encoding
The open-redirect primitive is *the resolved host/scheme changing*. Extra path/query on the author's own host is not a redirect. So the host/scheme/userinfo equality check is the load-bearing guard, and it preserves all legitimate URLs byte-for-byte.

## Tests
4 new unit tests in `test/resolver.test.ts` (`buildUrl` exported for testing): normal path substitution, **colon-preservation regression guard**, host-injection rejection (`https://{id}.example.com/`, `https://{id}/path` → dropped), non-absolute passthrough. **Full suite: 298 passed**, `tsc` clean for the change.

Generated from the audit patch `PATCHES/06-resolver-url-validation.patch.md`. The Server-API (Python) half of F-07-01 will be a separate PR on that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)